### PR TITLE
fix(docs): v1.6.3 — wrap statusLine command in bash -c across all setup guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.6.3 — 2026-04-12
+
+**Bug fixes:**
+- Fixed statusLine command in all setup guides — must be wrapped in `bash -c '...'` for external binaries to work (Claude Code does not capture stdout from direct `py`/`python3` invocations)
+- Added "Statusline not appearing" troubleshooting entry to all platform setup guides with correct/wrong examples
+- Fixed PowerShell helper snippet in `docs/setup-windows.md` to generate the `bash -c` wrapped command
+- Fixed typo in `tests.py` — `TestCalcCrossSesionCosts` → `TestCalcCrossSessionCosts`
+
+**Other:**
+- VERSION bumped to `1.6.3`
+
 ## v1.6.2 — 2026-04-10
 
 **Features:**

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,3 @@
+# Tasks
+
+No pending tasks.

--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -42,7 +42,7 @@ Add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "python3 /home/yourname/.cc-aio-mon/statusline.py"
+    "command": "bash -c 'python3 /home/yourname/.cc-aio-mon/statusline.py'"
   }
 }
 ```
@@ -89,6 +89,12 @@ python3 update.py --apply     # check + apply
 Restart Claude Code after updating. See [README — Updating](../README.md#updating) for full details.
 
 ## Troubleshooting
+
+**Statusline not appearing**
+- Claude Code's statusLine runs commands in a context where external binaries (`python3`, `python`) do not produce captured output. The command **must** be wrapped in `bash -c '...'`.
+- Correct: `"command": "bash -c 'python3 /home/you/.cc-aio-mon/statusline.py'"`
+- Wrong: `"command": "python3 /home/you/.cc-aio-mon/statusline.py"`
+- If the statusline was working before and stopped, verify the `bash -c` wrapper is still present in `~/.claude/settings.json`.
 
 **Monitor shows "Waiting for Claude Code session..."**
 - Check `statusLine.command` in `~/.claude/settings.json`.

--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -41,7 +41,7 @@ Add to `~/.claude/settings.json`:
 {
   "statusLine": {
     "type": "command",
-    "command": "python3 /Users/yourname/.cc-aio-mon/statusline.py"
+    "command": "bash -c 'python3 /Users/yourname/.cc-aio-mon/statusline.py'"
   }
 }
 ```
@@ -89,14 +89,17 @@ Restart Claude Code after updating. See [README — Updating](../README.md#updat
 
 ## Troubleshooting
 
+**Statusline not appearing**
+- Claude Code's statusLine runs commands in a context where external binaries (`python3`, `python`) do not produce captured output. The command **must** be wrapped in `bash -c '...'`.
+- Correct: `"command": "bash -c 'python3 /Users/you/.cc-aio-mon/statusline.py'"`
+- Wrong: `"command": "python3 /Users/you/.cc-aio-mon/statusline.py"`
+- If the statusline was working before and stopped, verify the `bash -c` wrapper is still present in `~/.claude/settings.json`.
+- After changing the command, restart Claude Code to pick up the new settings.
+
 **Monitor shows "Waiting for Claude Code session..."**
 - Check `statusLine.command` in `~/.claude/settings.json`.
 - Verify temp files appear after a Claude Code event: `/tmp/claude-aio-monitor/`
 - Test: `echo '{"context_window": {"used_percentage": 42}}' | python3 ~/.cc-aio-mon/statusline.py`
-
-**Statusline not appearing**
-- Verify the path in `statusLine.command`.
-- Ensure Claude Code reloaded the settings (restart Claude Code).
 
 **Raw escape codes visible**
 - Terminal.app supports truecolor since macOS 10.12.

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -37,7 +37,7 @@ Open `%USERPROFILE%\.claude\settings.json` (create the file if it doesn't exist)
 {
   "statusLine": {
     "type": "command",
-    "command": "py \"C:/Users/<your-username>/.cc-aio-mon/statusline.py\""
+    "command": "bash -c 'py C:/Users/<your-username>/.cc-aio-mon/statusline.py'"
   }
 }
 ```
@@ -48,7 +48,7 @@ Open `%USERPROFILE%\.claude\settings.json` (create the file if it doesn't exist)
 
 ```powershell
 $p = "$env:USERPROFILE\.cc-aio-mon\statusline.py" -replace '\\', '/'
-Write-Host "py `"$p`""
+Write-Host "bash -c 'py $p'"
 ```
 
 ## Step 4 — Launch the dashboard
@@ -92,6 +92,12 @@ py update.py --apply          # check + apply
 Restart Claude Code after updating. See [README — Updating](../README.md#updating) for full details.
 
 ## Troubleshooting
+
+**Statusline not appearing**
+- Claude Code's statusLine runs commands in a context where external binaries (`py`, `python`, `python3`) do not produce captured output. The command **must** be wrapped in `bash -c '...'`.
+- Correct: `"command": "bash -c 'py C:/Users/you/.cc-aio-mon/statusline.py'"`
+- Wrong: `"command": "py \"C:/Users/you/.cc-aio-mon/statusline.py\""`
+- If the statusline was working before and stopped, verify the `bash -c` wrapper is still present in `%USERPROFILE%\.claude\settings.json`.
 
 **`py` not found**
 - Reinstall Python from [python.org](https://www.python.org/downloads/). Check "Install Python Launcher" during setup.

--- a/monitor.py
+++ b/monitor.py
@@ -121,7 +121,7 @@ C_DIM = E + "38;2;76;86;106m"
 C_FG = E + "38;2;180;186;200m"
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
-VERSION = "1.6.2"
+VERSION = "1.6.3"
 _SID_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,128}$")
 _ANSI_RE = re.compile(r"\033\[[0-9;]*[a-zA-Z]")
 MAX_FILE_SIZE = 1_048_576  # 1 MB — keep in sync with statusline.py

--- a/tests.py
+++ b/tests.py
@@ -954,7 +954,7 @@ class TestTrimHistory(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # calc_cross_session_costs
 # ---------------------------------------------------------------------------
-class TestCalcCrossSesionCosts(unittest.TestCase):
+class TestCalcCrossSessionCosts(unittest.TestCase):
 
     def setUp(self):
         import tempfile, pathlib


### PR DESCRIPTION
## Summary
- Fixed statusLine command in all 3 platform setup guides — must be wrapped in `bash -c '...'` for external binaries (`py`, `python3`) to produce captured stdout in Claude Code's statusLine context
- Added "Statusline not appearing" troubleshooting entry to all platform guides with correct/wrong examples
- Fixed PowerShell helper snippet in `docs/setup-windows.md` to generate the `bash -c` wrapped command
- Fixed typo in `tests.py` — `TestCalcCrossSesionCosts` → `TestCalcCrossSessionCosts`
- VERSION bumped to `1.6.3`

## Test plan
- [x] `py -m py_compile monitor.py statusline.py rates.py update.py` — clean
- [x] `py tests.py` — 142/142 pass
- [x] All setup guides verified: zero bare `py`/`python3` in `"command"` JSON values
- [x] Troubleshooting sections consistent across all 3 guides (Statusline not appearing is first entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)