### PR TITLE
refactor: v1.6.4 — rename rates.py → shared.py, deduplicate helpers

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ What should change and how it should work.
 
 **Constraints to keep in mind**
 - Stdlib only (no pip packages)
-- Three runtime files (`statusline.py`, `monitor.py`, `rates.py`)
+- Three runtime files (`statusline.py`, `monitor.py`, `shared.py`)
 - Cross-platform (Windows, macOS, Linux)
 
 **Alternatives considered**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] `python3 tests.py` (or `py tests.py` on Windows) passes (all tests green)
-- [ ] All files compile: `python3 -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('rates.py','statusline.py','monitor.py','update.py')]"` (use `py` on Windows)
+- [ ] All files compile: `python3 -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('shared.py','statusline.py','monitor.py','update.py')]"` (use `py` on Windows)
 - [ ] Tested manually with a live Claude Code session
 - [ ] Zero new dependencies introduced
 - [ ] `MAX_FILE_SIZE` and ANSI palette kept in sync across `statusline.py` and `monitor.py` (if changed)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -19,7 +19,7 @@ You will receive a response within 7 days. If confirmed, a fix will be released 
 ## Scope
 
 **In scope:**
-- `monitor.py`, `statusline.py`, `rates.py`, `update.py`
+- `monitor.py`, `statusline.py`, `shared.py`, `update.py`
 - `check-requirements.ps1`, `check-requirements.sh`
 - Setup documentation under `docs/`
 - CI workflows under `.github/workflows/`

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Bandit
         run: pip install --require-hashes -r .github/workflows/requirements-bandit.txt
       - name: Run Bandit
-        run: bandit -r rates.py statusline.py monitor.py update.py -f sarif -o bandit.sarif --severity-level medium || true
+        run: bandit -r shared.py statusline.py monitor.py update.py -f sarif -o bandit.sarif --severity-level medium || true
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Compile check
-        run: python -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('rates.py','statusline.py','monitor.py','update.py')]"
+        run: python -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('shared.py','statusline.py','monitor.py','update.py')]"
       - name: Run tests
         run: python tests.py
     # Windows tests only Python 3.12 (excluded 3.8 combo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.6.4 — 2026-04-12
+
+**Refactor:**
+- Renamed `rates.py` → `shared.py` — now contains all shared helpers (`_num`, `_sanitize`, `f_dur`, `f_tok`, `f_cost`, `calc_rates`) used by both `statusline.py` and `monitor.py`
+- Removed duplicate function definitions from `statusline.py` and `monitor.py` — single source of truth in `shared.py`
+- Updated all documentation, CI workflows, and templates to reference `shared.py`
+
+**Other:**
+- VERSION bumped to `1.6.4`
+
 ## v1.6.3 — 2026-04-12
 
 **Bug fixes:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Constraints
 
 - **Stdlib only** — no pip installs, no node_modules.
-- **Three runtime files** — `statusline.py`, `monitor.py`, and shared `rates.py`. No additional runtime modules (test files like `tests.py` are not runtime).
+- **Three runtime files** — `statusline.py`, `monitor.py`, and shared `shared.py`. No additional runtime modules (test files like `tests.py` are not runtime).
 - **Cross-platform** — changes must work on Windows, macOS, and Linux.
 
 ## Before submitting
@@ -17,7 +17,7 @@
 
 2. Verify all files compile cleanly:
    ```bash
-   python3 -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('rates.py', 'statusline.py', 'monitor.py', 'update.py')]"
+   python3 -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('shared.py', 'statusline.py', 'monitor.py', 'update.py')]"
    ```
 
 3. Test manually on at least one platform with a live Claude Code session.
@@ -25,7 +25,7 @@
 ## What to keep in sync
 
 - `MAX_FILE_SIZE` is defined in both `statusline.py` and `monitor.py` — update both if you change it.
-- `calc_rates` lives in `rates.py` — imported by both `statusline.py` and `monitor.py`.
+- `calc_rates` lives in `shared.py` — imported by both `statusline.py` and `monitor.py`.
 - ANSI color palette (`C_RED`, `C_GRN`, etc.) is duplicated — keep both files consistent.
 
 ## Pull requests

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 **Real-time terminal monitor for Claude Code CLI.** Track context window usage, API rate limits, session costs, burn rate, and cache performance — all in one compact TUI dashboard. Stdlib only (Python 3.8+), cross-platform.
 
-> **How it works:** Claude Code pipes session telemetry as JSON to `statusline.py` via **stdin** after each assistant message, permission mode change, or vim mode toggle (300ms debounce). The script parses the JSON, renders a one-line ANSI status bar in the terminal, and writes the data to `$TMPDIR/claude-aio-monitor/` as atomic JSON snapshots + append-only JSONL history. A separate `monitor.py` process polls these temp files and renders a fullscreen TUI dashboard. Both scripts share `rates.py` for burn rate ($/min) and context rate (%/min) calculation. **Three Python files, stdlib only, no build step.**
+> **How it works:** Claude Code pipes session telemetry as JSON to `statusline.py` via **stdin** after each assistant message, permission mode change, or vim mode toggle (300ms debounce). The script parses the JSON, renders a one-line ANSI status bar in the terminal, and writes the data to `$TMPDIR/claude-aio-monitor/` as atomic JSON snapshots + append-only JSONL history. A separate `monitor.py` process polls these temp files and renders a fullscreen TUI dashboard. Both scripts share `shared.py` for burn rate ($/min) and context rate (%/min) calculation. **Three Python files, stdlib only, no build step.**
 
 | | |
 |---|---|
 | **Input** | Claude Code `statusLine` JSON protocol via stdin — model info, context window, rate limits, cost, token counts, session metadata |
 | **Output** | ANSI truecolor terminal — one-line statusline bar + fullscreen TUI dashboard with progress bars, smart alerts, cross-session cost aggregation |
 | **Data flow** | `Claude Code → stdin JSON → statusline.py → temp files → monitor.py → TUI` |
-| **Files** | `statusline.py` (statusline renderer + IPC writer), `monitor.py` (TUI dashboard), `rates.py` (shared rate math) |
+| **Files** | `statusline.py` (statusline renderer + IPC writer), `monitor.py` (TUI dashboard), `shared.py` (shared rate math) |
 | **IPC** | Atomic JSON snapshots + JSONL history in `$TMPDIR/claude-aio-monitor/` — no sockets, no databases |
 
 <p align="center"><img src="screenshots/cc-aio-mon-dashboard.png" alt="CC AIO MON — fullscreen TUI dashboard showing context window, API ratio, cache hit rate, rate limits, burn rate, cost, and cross-session totals with Nord color scheme"></p>
@@ -129,13 +129,13 @@ Claude Code ──stdin JSON──> statusline.py ──> terminal (one-line ANS
                                  v
                            monitor.py ──> terminal (fullscreen TUI)
 
-Both scripts import rates.py for shared BRN/CTR calculation.
+Both scripts import shared.py for shared BRN/CTR calculation.
 ```
 
 1. **Claude Code** emits JSON telemetry to `statusline.py` via stdin after each assistant message, permission mode change, or vim mode toggle (300ms debounce).
 2. **statusline.py** parses JSON, renders one-line ANSI status bar, writes atomic snapshot (`.json`) + appends to history (`.jsonl`).
 3. **monitor.py** polls temp directory (default 500ms), reads snapshots + history, renders fullscreen TUI with progress bars and computed metrics.
-4. **rates.py** provides `calc_rates()` — computes BRN ($/min) and CTR (%/min) from JSONL history timestamps.
+4. **shared.py** provides `calc_rates()` — computes BRN ($/min) and CTR (%/min) from JSONL history timestamps.
 
 ### Color Thresholds
 
@@ -240,11 +240,11 @@ After updating, restart Claude Code to pick up the new statusline. Optionally re
 
 ## Contributing
 
-Contributions welcome. Keep it stdlib only, ship `rates.py` alongside entry scripts, test on Windows and Unix. Before submitting, run the test suite and the compile check (`python3` on macOS/Linux, `py` on Windows):
+Contributions welcome. Keep it stdlib only, ship `shared.py` alongside entry scripts, test on Windows and Unix. Before submitting, run the test suite and the compile check (`python3` on macOS/Linux, `py` on Windows):
 
 ```bash
 python3 tests.py
-python3 -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('rates.py','statusline.py','monitor.py','update.py')]"
+python3 -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('shared.py','statusline.py','monitor.py','update.py')]"
 ```
 
 Open an issue first for anything non-trivial so the approach can be discussed before work begins. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for full guidelines.

--- a/monitor.py
+++ b/monitor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Claude AIO Monitor — fullscreen TUI dashboard for Claude Code.
 
-Terminal dashboard (monitor.py + rates.py). Stdlib only.
+Terminal dashboard (monitor.py + shared.py). Stdlib only.
 Reads shared state from statusline.py via temp files.
 
 Usage:
@@ -25,7 +25,7 @@ import tempfile
 import time
 from datetime import datetime
 
-from rates import calc_rates
+from shared import calc_rates, _num, _sanitize, f_tok, f_cost, f_dur
 
 # ---------------------------------------------------------------------------
 # Platform — keyboard input abstraction
@@ -121,7 +121,7 @@ C_DIM = E + "38;2;76;86;106m"
 C_FG = E + "38;2;180;186;200m"
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
-VERSION = "1.6.3"
+VERSION = "1.6.4"
 _SID_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,128}$")
 _ANSI_RE = re.compile(r"\033\[[0-9;]*[a-zA-Z]")
 MAX_FILE_SIZE = 1_048_576  # 1 MB — keep in sync with statusline.py
@@ -131,14 +131,6 @@ try:
     WARN_BRN = float(os.environ.get("CLAUDE_WARN_BRN", "0.50"))
 except (ValueError, TypeError):
     WARN_BRN = 0.50
-
-
-def _num(v, default=0):
-    """Safely coerce value to float (handles None, strings, etc.)."""
-    try:
-        return float(v) if v is not None else default
-    except (TypeError, ValueError):
-        return default
 
 
 def vlen(s):
@@ -174,11 +166,6 @@ def truncate(s, maxw):
     return result
 
 
-def _sanitize(s):
-    """Strip control characters to prevent terminal escape injection."""
-    return re.sub(r"[\x00-\x1f\x7f-\x9f]", "", str(s))
-
-
 # ---------------------------------------------------------------------------
 # Characters
 # ---------------------------------------------------------------------------
@@ -192,28 +179,6 @@ BAR_W = 25     # fixed bar width for ALL metrics
 # ---------------------------------------------------------------------------
 # Formatting
 # ---------------------------------------------------------------------------
-def f_tok(n):
-    n = _num(n, 0)
-    if n == 0:
-        return "--"
-    if n < 1000:
-        return f"{int(n):,}"
-    if n < 100_000:
-        return f"{n / 1000:.1f}k"
-    if n < 1_000_000:
-        return f"{n / 1000:.0f}k"
-    return f"{n / 1_000_000:.0f}M"
-
-
-def f_cost(usd):
-    usd = _num(usd, 0)
-    if usd <= 0:
-        return "--"
-    if usd < 0.01:
-        return f"{usd:.4f} $"
-    return f"{usd:.2f} $"
-
-
 def f_cd(epoch):
     if epoch is None:
         return "--"
@@ -229,20 +194,6 @@ def f_cd(epoch):
     if h > 0:
         return f"{h}h {m:02d}m"
     return f"{m}m"
-
-
-def f_dur(ms):
-    ms = _num(ms, 0)
-    if ms <= 0:
-        return "--"
-    s = int(ms / 1000)
-    if s < 60:
-        return f"{s}s"
-    m, s = divmod(s, 60)
-    if m < 60:
-        return f"{m}m {s:02d}s"
-    h, m = divmod(m, 60)
-    return f"{h}h {m:02d}m"
 
 
 # ---------------------------------------------------------------------------

--- a/shared.py
+++ b/shared.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Shared BRN/CTR rate calculation for monitor.py and statusline.py."""
+"""Shared helpers and rate calculation for monitor.py and statusline.py."""
+
+import re
 
 MIN_EPOCH = 1_577_836_800  # 2020-01-01 — reject implausible timestamps
 
@@ -9,6 +11,47 @@ def _num(v, default=0):
         return float(v) if v is not None else default
     except (TypeError, ValueError):
         return default
+
+
+def _sanitize(s):
+    """Strip control characters to prevent terminal escape injection."""
+    return re.sub(r"[\x00-\x1f\x7f-\x9f]", "", str(s))
+
+
+def f_dur(ms):
+    ms = _num(ms, 0)
+    if ms <= 0:
+        return "--"
+    s = int(ms / 1000)
+    if s < 60:
+        return f"{s}s"
+    m, s = divmod(s, 60)
+    if m < 60:
+        return f"{m}m {s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h {m:02d}m"
+
+
+def f_tok(n):
+    n = _num(n, 0)
+    if n == 0:
+        return "--"
+    if n < 1000:
+        return f"{int(n):,}"
+    if n < 100_000:
+        return f"{n / 1000:.1f}k"
+    if n < 1_000_000:
+        return f"{n / 1000:.0f}k"
+    return f"{n / 1_000_000:.0f}M"
+
+
+def f_cost(usd):
+    usd = _num(usd, 0)
+    if usd <= 0:
+        return "--"
+    if usd < 0.01:
+        return f"{usd:.4f} $"
+    return f"{usd:.2f} $"
 
 
 def calc_rates(hist):

--- a/statusline.py
+++ b/statusline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Claude AIO Monitor — statusline for Claude Code.
 
-Stdlib-only status line script (uses rates.py for BRN/CTR).
+Stdlib-only status line script (uses shared.py for helpers and BRN/CTR).
 Reads JSON from stdin (Claude Code status line protocol), outputs ANSI-colored text.
 Responsive layout adapts to terminal width.
 
@@ -21,7 +21,7 @@ import tempfile
 import time
 from datetime import datetime
 
-from rates import calc_rates as _calc_rates
+from shared import calc_rates as _calc_rates, _num, _sanitize, f_dur, f_tok, f_cost
 
 # ---------------------------------------------------------------------------
 # Config
@@ -142,58 +142,9 @@ SEP = f" {C_DIM}\u2502{RB} "  # │
 SEP_VLEN = 3  # " │ "
 
 
-def _num(v, default=0):
-    """Safely coerce value to float (handles None, strings, etc.)."""
-    try:
-        return float(v) if v is not None else default
-    except (TypeError, ValueError):
-        return default
-
-
-def f_dur(ms):
-    ms = _num(ms, 0)
-    if ms <= 0:
-        return "--"
-    s = int(ms / 1000)
-    if s < 60:
-        return f"{s}s"
-    m, s = divmod(s, 60)
-    if m < 60:
-        return f"{m}m {s:02d}s"
-    h, m = divmod(m, 60)
-    return f"{h}h {m:02d}m"
-
-
-def f_tok(n):
-    n = _num(n, 0)
-    if n == 0:
-        return "--"
-    if n < 1000:
-        return f"{int(n):,}"
-    if n < 100_000:
-        return f"{n / 1000:.1f}k"
-    if n < 1_000_000:
-        return f"{n / 1000:.0f}k"
-    return f"{n / 1_000_000:.0f}M"
-
-
-def f_cost(usd):
-    usd = _num(usd, 0)
-    if usd <= 0:
-        return "--"
-    if usd < 0.01:
-        return f"{usd:.4f} $"
-    return f"{usd:.2f} $"
-
-
 # ---------------------------------------------------------------------------
 # Segment builders — each returns (text, visible_length) or None
 # ---------------------------------------------------------------------------
-def _sanitize(s):
-    """Strip control characters to prevent terminal escape injection."""
-    return re.sub(r"[\x00-\x1f\x7f-\x9f]", "", str(s))
-
-
 def seg_model(data):
     name = _sanitize(data.get("model", {}).get("display_name", ""))
     # Shorten known model names

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,7 @@ import sys
 import time
 import unittest
 
-import rates
+import shared
 
 # Import target functions directly
 from monitor import (
@@ -227,8 +227,8 @@ class TestCalcRates(unittest.TestCase):
 
     def test_shared_module_identity(self):
         from monitor import calc_rates as m_cr
-        self.assertIs(m_cr, rates.calc_rates)
-        self.assertIs(sl_calc_rates, rates.calc_rates)
+        self.assertIs(m_cr, shared.calc_rates)
+        self.assertIs(sl_calc_rates, shared.calc_rates)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Renamed `rates.py` → `shared.py` — now contains all shared helpers (`_num`, `_sanitize`, `f_dur`, `f_tok`, `f_cost`, `calc_rates`)
- Removed 5 duplicate function definitions from `statusline.py` and `monitor.py` (net -45 lines)
- Updated all imports, docs, CI workflows, templates, and security scope

## Test plan
- [x] `py -m py_compile shared.py statusline.py monitor.py update.py` — clean
- [x] `py tests.py` — 142/142 pass
- [x] Zero stale `rates.py` references outside CHANGELOG history
- [x] No duplicate helper definitions remain in statusline.py or monitor.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)