### PR TITLE
docs: update three runtime files → four (add update.py)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ What should change and how it should work.
 
 **Constraints to keep in mind**
 - Stdlib only (no pip packages)
-- Three runtime files (`statusline.py`, `monitor.py`, `shared.py`)
+- Four runtime files (`statusline.py`, `monitor.py`, `shared.py`, `update.py`)
 - Cross-platform (Windows, macOS, Linux)
 
 **Alternatives considered**

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 # Claude Code local config
 .claude/
 TASKS.md
+PROMO.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Constraints
 
 - **Stdlib only** — no pip installs, no node_modules.
-- **Three runtime files** — `statusline.py`, `monitor.py`, and shared `shared.py`. No additional runtime modules (test files like `tests.py` are not runtime).
+- **Four runtime files** — `statusline.py`, `monitor.py`, `shared.py`, and `update.py`. No additional runtime modules (test files like `tests.py` are not runtime).
 - **Cross-platform** — changes must work on Windows, macOS, and Linux.
 
 ## Before submitting

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 **Real-time terminal monitor for Claude Code CLI.** Track context window usage, API rate limits, session costs, burn rate, and cache performance — all in one compact TUI dashboard. Stdlib only (Python 3.8+), cross-platform.
 
-> **How it works:** Claude Code pipes session telemetry as JSON to `statusline.py` via **stdin** after each assistant message, permission mode change, or vim mode toggle (300ms debounce). The script parses the JSON, renders a one-line ANSI status bar in the terminal, and writes the data to `$TMPDIR/claude-aio-monitor/` as atomic JSON snapshots + append-only JSONL history. A separate `monitor.py` process polls these temp files and renders a fullscreen TUI dashboard. Both scripts share `shared.py` for burn rate ($/min) and context rate (%/min) calculation. **Three Python files, stdlib only, no build step.**
+> **How it works:** Claude Code pipes session telemetry as JSON to `statusline.py` via **stdin** after each assistant message, permission mode change, or vim mode toggle (300ms debounce). The script parses the JSON, renders a one-line ANSI status bar in the terminal, and writes the data to `$TMPDIR/claude-aio-monitor/` as atomic JSON snapshots + append-only JSONL history. A separate `monitor.py` process polls these temp files and renders a fullscreen TUI dashboard. Both scripts share `shared.py` for burn rate ($/min) and context rate (%/min) calculation. **Four Python files, stdlib only, no build step.**
 
 | | |
 |---|---|
 | **Input** | Claude Code `statusLine` JSON protocol via stdin — model info, context window, rate limits, cost, token counts, session metadata |
 | **Output** | ANSI truecolor terminal — one-line statusline bar + fullscreen TUI dashboard with progress bars, smart alerts, cross-session cost aggregation |
 | **Data flow** | `Claude Code → stdin JSON → statusline.py → temp files → monitor.py → TUI` |
-| **Files** | `statusline.py` (statusline renderer + IPC writer), `monitor.py` (TUI dashboard), `shared.py` (shared rate math) |
+| **Files** | `statusline.py` (statusline renderer + IPC writer), `monitor.py` (TUI dashboard), `shared.py` (shared helpers + rate math), `update.py` (self-updater) |
 | **IPC** | Atomic JSON snapshots + JSONL history in `$TMPDIR/claude-aio-monitor/` — no sockets, no databases |
 
 <p align="center"><img src="screenshots/cc-aio-mon-dashboard.png" alt="CC AIO MON — fullscreen TUI dashboard showing context window, API ratio, cache hit rate, rate limits, burn rate, cost, and cross-session totals with Nord color scheme"></p>


### PR DESCRIPTION
## Summary
- README.md: "Three Python files" → "Four Python files", added update.py to Files table
- CONTRIBUTING.md: "Three runtime files" → "Four runtime files"
- feature_request.md: same fix

update.py was added in v1.6.2 but file count was never updated.

## Test plan
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)