### PR TITLE
feat(monitor): v1.7.0 — usage stats modal

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+CC AIO MON — real-time terminal monitoring dashboard for Claude Code CLI. Pure Python, stdlib only, zero dependencies.
+
+## Architecture
+
+```
+Claude Code → stdin JSON → statusline.py → $TMPDIR/claude-aio-monitor/ → monitor.py → TUI
+```
+
+- **statusline.py** — reads Claude Code statusLine JSON from stdin, renders ANSI bar, writes atomic snapshots + JSONL history to temp dir
+- **monitor.py** — fullscreen TUI dashboard, polls temp files every 500ms, renders live metrics, keyboard shortcuts, usage stats modal (reads `~/.claude/projects/` transcripts)
+- **shared.py** — shared BRN ($/min) and CTR (%/min) calculation from JSONL history
+- **update.py** — self-update checker with git pull --ff-only safety guards
+- **tests.py** — unit tests, stdlib unittest
+
+## Commands
+
+- Test: `py tests.py` (Windows) / `python3 tests.py` (Unix)
+- Test single: `py -m unittest tests.TestClassName.test_method`
+- Lint: `py -m py_compile monitor.py statusline.py shared.py update.py`
+- Run monitor: `py monitor.py`
+- Run statusline: configured via Claude Code settings.json, reads stdin
+
+## statusLine config
+
+Claude Code statusLine command MUST be wrapped in `bash -c '...'` — externé binárky (py, python, python3) nefungujú priamo, len bash builtiny. Toto platí pre všetky platformy.
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash -c 'py C:/path/to/statusline.py'"
+  }
+}
+```
+
+## Rules
+
+- Zero external dependencies — stdlib only, no pip packages
+- All file I/O confined to temp directory ($TMPDIR/claude-aio-monitor/) and ~/.claude/projects/ (read-only, for usage stats)
+- Session IDs validated with regex: `^[a-zA-Z0-9_\-]{1,128}$`
+- Atomic writes via NamedTemporaryFile + os.replace()
+- File size limits: JSON 1MB, JSONL 10MB read / 1MB trim
+- Cross-platform: Windows (py, ctypes, msvcrt) + Unix (python3, termios, select)
+- ANSI 24-bit color — Windows Terminal required on Windows
+- Python 3.8+ compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.7.0 — 2026-04-12
+
+**Features:**
+- Usage stats modal (`u` key) — per-model token breakdown (In/Out/Calls) with progress bars, overview metrics (SES, DAY, STK, LSS, TOP), period filter (All Time / 7 Days / 30 Days). Reads session transcripts from `~/.claude/projects/`
+- New dashboard footer shortcut: `[u]us`
+- Legend updated with USAGE STATS section documenting new metrics
+
+**Bug fixes:**
+- `_parse_ts` now handles negative UTC offsets (`-HH:MM`) on Python 3.8+
+- Removed duplicate `sid_str` assignment in `render_frame`
+- Removed duplicate `day` calculation in transcript scanner
+- Cache TTL switched from `time.time()` to `time.monotonic()` for clock-jump robustness
+
+**Tests:**
+- Added 39 new tests (142 → 181): `TestParseTs`, `TestCalcStreaks`, `TestModelLabel`, `TestScanTranscriptStats`, `TestRenderStats`, `TestRenderLegend`, `TestRenderFrame`
+
+**Other:**
+- VERSION bumped to `1.7.0`
+
 ## v1.6.4 — 2026-04-12
 
 **Refactor:**

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Other monitors scrape log files or estimate costs from token counts. CC AIO MON 
 - **Progress bars with fixed ranges** — BRN (0-1.0 $/min), CTR (0-5.0 %/min), CST (0-$50) plus standard 0-100% bars for APR, CHR, CTX, 5HL, 7DL.
 - **Smart warnings** — header alerts when context fills in < 30 min, rate limits > 80%, or burn rate exceeds threshold.
 - **Cross-session cost tracking** — TDY (today) and WEK (rolling 7-day) aggregate cost across all active Claude Code sessions.
+- **Usage stats modal** — press `u` for a per-model token breakdown (In/Out/Calls), session count, active days, streaks, longest session, and most active day. Reads `~/.claude/projects/` transcripts. Filterable by All Time / Last 7 Days / Last 30 Days.
 - **Cross-platform** — Windows (Terminal, PowerShell, Git Bash), macOS (Terminal, iTerm2), Linux. CI-tested: Ubuntu (Python 3.8 + 3.12), Windows (Python 3.12). macOS: not CI-tested.
 - **Nord truecolor palette** — ANSI 24-bit color with semantic grouping: green = performance, cyan = context, yellow = rate limits, orange = cost/finance, red = critical.
 - **Responsive layout** — statusline drops right segments for narrow terminals. Dashboard compresses sections automatically.
@@ -84,6 +85,11 @@ Press `r` to force a refresh (resets the stale timer if new data has arrived), o
 | **DUR** | Session duration | — | statusline |
 | **NOW** | Current clock time | HH:MM:SS | statusline + dashboard |
 | **UPD** | Last data update age | — | dashboard |
+| **SES** | Total sessions | — | usage stats modal |
+| **DAY** | Active days | — | usage stats modal |
+| **STK** | Streak (current/best) | — | usage stats modal |
+| **LSS** | Longest session | — | usage stats modal |
+| **TOP** | Most active day | — | usage stats modal |
 
 ## Usage
 
@@ -108,9 +114,11 @@ python3 monitor.py --refresh 1000  # custom refresh interval (ms, default 500)
 |-----|--------|
 | `q` | Quit |
 | `r` | Force refresh (resets stale timer) |
-| `l` | Toggle legend overlay |
 | `s` | Switch session (picker) |
+| `u` | Usage stats modal (per-model breakdown) |
+| `l` | Toggle legend overlay |
 | `1-9` | Select session (picker) |
+| `1/2/3` | Switch period in usage stats modal (all/7d/30d) |
 
 ### Session Picker
 

--- a/monitor.py
+++ b/monitor.py
@@ -28,6 +28,178 @@ from datetime import datetime
 from shared import calc_rates, _num, _sanitize, f_tok, f_cost, f_dur
 
 # ---------------------------------------------------------------------------
+# Transcript usage scanner — reads ~/.claude/projects/**/*.jsonl
+# ---------------------------------------------------------------------------
+_CLAUDE_DIR = pathlib.Path.home() / ".claude" / "projects"
+_usage_cache = {}
+
+
+def _parse_ts(ts_str):
+    """Parse ISO timestamp to epoch, 3.8 compatible. Returns 0 on failure."""
+    if not ts_str:
+        return 0
+    try:
+        # Strip timezone suffix for 3.8 compat: Z, +HH:MM, -HH:MM
+        clean = ts_str.replace("Z", "")
+        # Remove +/-offset after the time portion (T required)
+        t_pos = clean.find("T")
+        if t_pos >= 0:
+            tail = clean[t_pos + 1:]
+            for sep in ("+", "-"):
+                idx = tail.rfind(sep)
+                # Offset separator is after HH:MM:SS (idx >= 8)
+                if idx >= 8:
+                    clean = clean[:t_pos + 1 + idx]
+                    break
+        return datetime.fromisoformat(clean).timestamp()
+    except (ValueError, TypeError):
+        return 0
+
+
+def scan_transcript_stats(period="all", ttl=30.0):
+    """Scan CC session transcripts, return (models, overview) tuple.
+
+    models: {model_id: {"input": int, "output": int, "calls": int}}
+    overview: {"sessions": int, "active_days": set, "longest_dur_ms": float,
+               "first_date": str, "daily_tokens": {date_str: int}}
+    """
+    now = time.monotonic()
+    cached = _usage_cache.get(period)
+    if cached and now - cached["t"] < ttl:
+        return cached["models"], cached["overview"]
+
+    cutoff = 0
+    if period == "7d":
+        cutoff = now - 7 * 86400
+    elif period == "30d":
+        cutoff = now - 30 * 86400
+
+    models = {}
+    active_days = set()
+    daily_tokens = {}
+    session_times = {}  # sid -> (first_ts, last_ts)
+    session_count = 0
+
+    if not _CLAUDE_DIR.is_dir():
+        empty_ov = {"sessions": 0, "active_days": set(), "longest_dur_ms": 0,
+                     "first_date": None, "daily_tokens": {}}
+        return models, empty_ov
+
+    for jl in _CLAUDE_DIR.glob("**/*.jsonl"):
+        # Skip subagent transcripts for session counting
+        is_subagent = "subagents" in str(jl)
+        try:
+            st = jl.stat()
+            if st.st_size > 50_000_000:
+                continue
+            if cutoff and st.st_mtime < cutoff:
+                continue
+        except OSError:
+            continue
+
+        sid = jl.stem
+        if not is_subagent:
+            session_count += 1
+
+        try:
+            with open(jl, encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    ts_str = obj.get("timestamp", "")
+                    ts = _parse_ts(ts_str)
+
+                    if cutoff and ts > 0 and ts < cutoff:
+                        continue
+
+                    # Track session timestamps for duration calc
+                    if ts > 0 and not is_subagent:
+                        if sid not in session_times:
+                            session_times[sid] = [ts, ts]
+                        else:
+                            if ts < session_times[sid][0]:
+                                session_times[sid][0] = ts
+                            if ts > session_times[sid][1]:
+                                session_times[sid][1] = ts
+
+                    if obj.get("type") != "assistant":
+                        continue
+                    msg = obj.get("message")
+                    if not msg or "usage" not in msg:
+                        continue
+
+                    model = msg.get("model", "unknown")
+                    u = msg["usage"]
+                    inp = int(_num(u.get("input_tokens", 0)))
+                    out = int(_num(u.get("output_tokens", 0)))
+                    if model not in models:
+                        models[model] = {"input": 0, "output": 0, "calls": 0}
+                    models[model]["input"] += inp
+                    models[model]["output"] += out
+                    models[model]["calls"] += 1
+
+                    # Track active days and daily tokens
+                    if ts > 0:
+                        day = datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+                        active_days.add(day)
+                        daily_tokens[day] = daily_tokens.get(day, 0) + inp + out
+        except (OSError, UnicodeDecodeError):
+            continue
+
+    # Compute longest session duration
+    longest_dur_ms = 0
+    for s_ts in session_times.values():
+        dur = (s_ts[1] - s_ts[0]) * 1000
+        if dur > longest_dur_ms:
+            longest_dur_ms = dur
+
+    # First date
+    first_date = min(active_days) if active_days else None
+
+    overview = {
+        "sessions": session_count,
+        "active_days": active_days,
+        "longest_dur_ms": longest_dur_ms,
+        "first_date": first_date,
+        "daily_tokens": daily_tokens,
+    }
+
+    _usage_cache[period] = {"t": now, "models": models, "overview": overview}
+    return models, overview
+
+
+def _calc_streaks(active_days):
+    """Calculate current and longest streak from a set of date strings."""
+    if not active_days:
+        return 0, 0
+    from datetime import timedelta
+    days = sorted(datetime.strptime(d, "%Y-%m-%d").date() for d in active_days)
+    today = datetime.now().date()
+
+    longest = 1
+    current_run = 1
+    for i in range(1, len(days)):
+        if (days[i] - days[i - 1]).days == 1:
+            current_run += 1
+            longest = max(longest, current_run)
+        else:
+            current_run = 1
+
+    # Current streak: count backwards from today
+    current = 0
+    check = today
+    for d in reversed(days):
+        if d == check:
+            current += 1
+            check -= timedelta(days=1)
+        elif d < check:
+            break
+    return current, longest
+
+# ---------------------------------------------------------------------------
 # Platform — keyboard input abstraction
 # ---------------------------------------------------------------------------
 IS_WIN = platform.system() == "Windows"
@@ -121,7 +293,7 @@ C_DIM = E + "38;2;76;86;106m"
 C_FG = E + "38;2;180;186;200m"
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
-VERSION = "1.6.4"
+VERSION = "1.7.0"
 _SID_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,128}$")
 _ANSI_RE = re.compile(r"\033\[[0-9;]*[a-zA-Z]")
 MAX_FILE_SIZE = 1_048_576  # 1 MB — keep in sync with statusline.py
@@ -345,7 +517,7 @@ def calc_cross_session_costs():
 
 def cached_cross_session_costs(ttl=30.0):
     """Cached version — refreshes every ttl seconds."""
-    now = time.time()
+    now = time.monotonic()
     if now - _cost_cache["t"] < ttl:
         return _cost_cache["today"], _cost_cache["week"]
     today, week = calc_cross_session_costs()
@@ -629,7 +801,6 @@ def render_frame(data, hist, cols, rows, show_legend=False, stale=False):
     brn_val = f"{cpm:.4f} $/min" if cpm and cpm > 0.0001 else "collecting..."
     ctr_val = f"{xpm:.2f} %/min" if xpm and xpm > 0.001 else "--"
     now = datetime.now().strftime("%H:%M:%S")
-    sid_str = str(data.get("session_id", "default"))
     if _SID_RE.match(sid_str):
         try:
             mt = (DATA_DIR / f"{sid_str}.json").stat().st_mtime
@@ -663,7 +834,7 @@ def render_frame(data, hist, cols, rows, show_legend=False, stale=False):
 
     # ── Footer ──────────────────────────────────────────────
     buf.append(sep(SW))
-    buf.append(f"{C_DIM}[{R}{C_WHT}q{R}{C_DIM}]qt{R}  {C_DIM}[{R}{C_WHT}r{R}{C_DIM}]rf{R}  {C_DIM}[{R}{C_WHT}s{R}{C_DIM}]se{R}  {C_DIM}[{R}{C_WHT}l{R}{C_DIM}]le{R}")
+    buf.append(f"{C_DIM}[{R}{C_WHT}q{R}{C_DIM}]qt{R}  {C_DIM}[{R}{C_WHT}r{R}{C_DIM}]rf{R}  {C_DIM}[{R}{C_WHT}s{R}{C_DIM}]se{R}  {C_DIM}[{R}{C_WHT}u{R}{C_DIM}]us{R}  {C_DIM}[{R}{C_WHT}l{R}{C_DIM}]le{R}")
 
     _fit_buf_height(buf, rows, clip_tail=False)
     return buf
@@ -701,10 +872,120 @@ def render_legend(cols, rows):
     buf.append(f"{C_WHT}q{R}    {C_DIM}Quit{R}")
     buf.append(f"{C_WHT}r{R}    {C_DIM}Refresh (reset stale){R}")
     buf.append(f"{C_WHT}s{R}    {C_DIM}Session picker{R}")
-    buf.append(f"{C_WHT}l{R}    {C_DIM}Legend toggle{R}")
+    buf.append(f"{C_WHT}u{R}    {C_DIM}Usage stats{R}")
     buf.append(f"{C_WHT}1-9{R}  {C_DIM}Select session{R}")
+    buf.append(f"{C_WHT}l{R}    {C_DIM}Legend toggle{R}")
+    buf.append("")
+    buf.append(f"{C_WHT}{B}USAGE STATS{R}")
+    buf.append(sep(SW))
+    buf.append(f"{C_WHT}SES{R}  {C_DIM}Total Sessions{R}")
+    buf.append(f"{C_WHT}DAY{R}  {C_DIM}Active Days{R}")
+    buf.append(f"{C_WHT}STK{R}  {C_DIM}Streak (current/best){R}")
+    buf.append(f"{C_WHT}LSS{R}  {C_DIM}Longest Session{R}")
+    buf.append(f"{C_WHT}TOP{R}  {C_DIM}Most Active Day{R}")
     buf.append(sep(SW))
     buf.append(f"{C_DIM}press any key to close{R}")
+
+    _fit_buf_height(buf, rows, clip_tail=True)
+    return buf
+
+
+# ---------------------------------------------------------------------------
+# Usage stats modal
+# ---------------------------------------------------------------------------
+_PERIOD_LABELS = {"all": "All Time", "7d": "Last 7 Days", "30d": "Last 30 Days"}
+_PERIOD_CYCLE = ["all", "7d", "30d"]
+
+# Short display names for known model IDs
+_MODEL_NAMES = {
+    "claude-opus-4-6": "Opus 4.6",
+    "claude-sonnet-4-6": "Sonnet 4.6",
+    "claude-haiku-4-5-20251001": "Haiku 4.5",
+}
+
+
+def _model_label(model_id):
+    return _MODEL_NAMES.get(model_id, model_id)
+
+
+# Bar colors per model (consistent mapping)
+_MODEL_COLORS = [C_CYN, C_GRN, C_YEL, C_ORN, C_RED]
+
+
+def render_stats(cols, rows, period="all"):
+    SW = cols
+    buf = []
+    buf.append(sep(SW))
+    title = f"USAGE STATS  {_PERIOD_LABELS.get(period, period)}"
+    tp = max(0, SW - len(title))
+    buf.append(f"{BG_BAR}{C_WHT}{B}{title}{R}{BG_BAR}{' ' * tp}{R}")
+    buf.append(sep(SW))
+
+    models, overview = scan_transcript_stats(period)
+    if not models:
+        buf.append(f"  {C_DIM}No transcript data found in ~/.claude/projects/{R}")
+        buf.append(f"  {C_DIM}(stats appear after at least one CC session){R}")
+        buf.append(sep(SW))
+        buf.append(f"{C_DIM}[1]all  [2]7d  [3]30d{R}")
+        buf.append("")
+        buf.append(f"{C_DIM}press any other key to close{R}")
+        _fit_buf_height(buf, rows, clip_tail=True)
+        return buf
+
+    # -- Overview section --
+    n_sessions = overview["sessions"]
+    n_days = len(overview["active_days"])
+    longest_ms = overview["longest_dur_ms"]
+    daily = overview["daily_tokens"]
+    current_streak, longest_streak = _calc_streaks(overview["active_days"])
+
+    # Most active day
+    most_active = "--"
+    if daily:
+        top_day = max(daily, key=daily.get)
+        most_active = f"{top_day} ({f_tok(daily[top_day])})"
+
+    buf.append(f"  {C_WHT}SES{R} {C_CYN}{n_sessions}{R}  {C_WHT}DAY{R} {C_CYN}{n_days}{R}  {C_WHT}STK{R} {C_CYN}{current_streak}d{R}{C_DIM}/{longest_streak}d{R}")
+    buf.append(f"  {C_WHT}LSS{R} {C_CYN}{f_dur(longest_ms)}{R}  {C_WHT}TOP{R} {C_CYN}{most_active}{R}")
+    buf.append(sep(SW))
+
+    # -- Models section --
+    # Sort by total tokens descending
+    total_all = sum(m["input"] + m["output"] for m in models.values())
+    sorted_models = sorted(
+        models.items(), key=lambda kv: kv[1]["input"] + kv[1]["output"], reverse=True
+    )
+
+    for i, (mid, st) in enumerate(sorted_models):
+        color = _MODEL_COLORS[i % len(_MODEL_COLORS)]
+        label = _model_label(mid)
+        total_m = st["input"] + st["output"]
+        pct = total_m / total_all * 100 if total_all else 0
+        buf.append(f"  {color}{B}{label}{R}  {C_DIM}({pct:.1f}%){R}")
+        buf.append(f"  {mkbar(pct, color)}")
+        buf.append(
+            f"    {C_DIM}In:{R} {color}{f_tok(st['input'])}{R}"
+            f"  {C_DIM}Out:{R} {color}{f_tok(st['output'])}{R}"
+            f"  {C_DIM}Calls:{R} {color}{st['calls']:,}{R}"
+        )
+        buf.append("")
+
+    # Totals
+    total_in = sum(m["input"] for m in models.values())
+    total_out = sum(m["output"] for m in models.values())
+    total_calls = sum(m["calls"] for m in models.values())
+    buf.append(sep(SW))
+    buf.append(
+        f"  {C_WHT}{B}Total{R}"
+        f"  {C_DIM}In:{R} {C_WHT}{f_tok(total_in)}{R}"
+        f"  {C_DIM}Out:{R} {C_WHT}{f_tok(total_out)}{R}"
+        f"  {C_DIM}Calls:{R} {C_WHT}{total_calls:,}{R}"
+    )
+
+    buf.append(sep(SW))
+    buf.append(f"{C_DIM}[{R}{C_WHT}1{R}{C_DIM}]all  [{R}{C_WHT}2{R}{C_DIM}]7d  [{R}{C_WHT}3{R}{C_DIM}]30d{R}")
+    buf.append("")
+    buf.append(f"{C_DIM}press any other key to close{R}")
 
     _fit_buf_height(buf, rows, clip_tail=True)
     return buf
@@ -815,6 +1096,7 @@ def main():
         print(f"Invalid session ID: {sid}")
         return
     show_legend = False
+    show_stats = None  # None=off, "all"/"7d"/"30d"=active period
     _render_errors = 0
     last_mt = 0
     last_seen = 0  # monotonic timestamp of last successful data load
@@ -849,12 +1131,32 @@ def main():
                 last_hist = []
             elif k == "l":
                 show_legend = not show_legend
+                show_stats = None
+            elif k == "u":
+                if show_stats is not None:
+                    show_stats = None
+                else:
+                    show_stats = "all"
+                    show_legend = False
+            elif show_stats is not None and k in ("1", "2", "3"):
+                show_stats = _PERIOD_CYCLE[int(k) - 1]
+            elif show_stats is not None and k is not None:
+                show_stats = None
             elif show_legend and k is not None:
                 show_legend = False
 
             # Render every tick when we have data (for spinner), reload data on interval
             need_render = size_changed or last_data is not None or since_data >= data_interval
             if not need_render:
+                time.sleep(tick)
+                continue
+
+            # Stats modal can render without a session (global data)
+            if show_stats is not None:
+                try:
+                    flush(render_stats(cols, rows, show_stats), cols)
+                except (TypeError, ValueError, KeyError, OSError):
+                    pass
                 time.sleep(tick)
                 continue
 

--- a/tests.py
+++ b/tests.py
@@ -18,6 +18,9 @@ from monitor import (
     _limit_color, _reset_color, collect_warnings,
     truncate, vlen, mkbar,
     calc_cross_session_costs,
+    _parse_ts, _calc_streaks, _model_label,
+    scan_transcript_stats, render_stats, render_legend, render_frame,
+    _CLAUDE_DIR, _usage_cache,
     WARN_BRN, BRN_MAX, CTR_MAX, CST_MAX,
     BAR_W, MAX_FILE_SIZE, _SID_RE, _ANSI_RE as M_ANSI_RE,
     C_RED as M_RED, C_YEL as M_YEL, C_GRN as M_GRN, C_DIM as M_DIM,
@@ -995,6 +998,413 @@ class TestCalcCrossSessionCosts(unittest.TestCase):
         jl.write_text('{"t": 1, "cost": {"total_cost_usd": 999}}\n', encoding="utf-8")
         today, week = calc_cross_session_costs()
         self.assertEqual(today, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _parse_ts
+# ---------------------------------------------------------------------------
+class TestParseTs(unittest.TestCase):
+
+    def test_iso_basic(self):
+        ts = _parse_ts("2026-04-12T17:23:27.144")
+        self.assertGreater(ts, 0)
+
+    def test_iso_z_suffix(self):
+        ts = _parse_ts("2026-04-12T17:23:27.144Z")
+        self.assertGreater(ts, 0)
+
+    def test_iso_positive_offset(self):
+        ts = _parse_ts("2026-04-12T17:23:27.144+05:30")
+        self.assertGreater(ts, 0)
+
+    def test_iso_negative_offset(self):
+        ts = _parse_ts("2026-04-12T17:23:27.144-05:00")
+        self.assertGreater(ts, 0)
+
+    def test_empty_string(self):
+        self.assertEqual(_parse_ts(""), 0)
+
+    def test_none(self):
+        self.assertEqual(_parse_ts(None), 0)
+
+    def test_malformed(self):
+        self.assertEqual(_parse_ts("not-a-date"), 0)
+
+    def test_consistent_across_formats(self):
+        """Z and no-tz should produce the same result (both naive local)."""
+        a = _parse_ts("2026-04-12T17:23:27")
+        b = _parse_ts("2026-04-12T17:23:27Z")
+        self.assertEqual(a, b)
+
+
+# ---------------------------------------------------------------------------
+# _calc_streaks
+# ---------------------------------------------------------------------------
+class TestCalcStreaks(unittest.TestCase):
+
+    def test_empty_returns_0_0(self):
+        self.assertEqual(_calc_streaks(set()), (0, 0))
+
+    def test_single_day_today(self):
+        from datetime import datetime
+        today = datetime.now().strftime("%Y-%m-%d")
+        current, longest = _calc_streaks({today})
+        self.assertEqual(current, 1)
+        self.assertEqual(longest, 1)
+
+    def test_single_day_past(self):
+        current, longest = _calc_streaks({"2020-01-01"})
+        self.assertEqual(current, 0)
+        self.assertEqual(longest, 1)
+
+    def test_consecutive_3_days_ending_today(self):
+        from datetime import datetime, timedelta
+        today = datetime.now().date()
+        days = {(today - timedelta(days=i)).strftime("%Y-%m-%d") for i in range(3)}
+        current, longest = _calc_streaks(days)
+        self.assertEqual(current, 3)
+        self.assertEqual(longest, 3)
+
+    def test_gap_breaks_streak(self):
+        from datetime import datetime, timedelta
+        today = datetime.now().date()
+        # today + 3 days ago (gap at yesterday)
+        days = {
+            today.strftime("%Y-%m-%d"),
+            (today - timedelta(days=3)).strftime("%Y-%m-%d"),
+        }
+        current, longest = _calc_streaks(days)
+        self.assertEqual(current, 1)
+        self.assertEqual(longest, 1)
+
+    def test_longest_in_past_not_current(self):
+        from datetime import datetime, timedelta
+        today = datetime.now().date()
+        # 5-day streak in past, 1-day current
+        past = {(today - timedelta(days=20 + i)).strftime("%Y-%m-%d") for i in range(5)}
+        current_day = {today.strftime("%Y-%m-%d")}
+        current, longest = _calc_streaks(past | current_day)
+        self.assertEqual(current, 1)
+        self.assertEqual(longest, 5)
+
+
+# ---------------------------------------------------------------------------
+# _model_label
+# ---------------------------------------------------------------------------
+class TestModelLabel(unittest.TestCase):
+
+    def test_known_opus(self):
+        self.assertEqual(_model_label("claude-opus-4-6"), "Opus 4.6")
+
+    def test_known_sonnet(self):
+        self.assertEqual(_model_label("claude-sonnet-4-6"), "Sonnet 4.6")
+
+    def test_known_haiku(self):
+        self.assertEqual(_model_label("claude-haiku-4-5-20251001"), "Haiku 4.5")
+
+    def test_unknown_passthrough(self):
+        self.assertEqual(_model_label("claude-future-99"), "claude-future-99")
+
+
+# ---------------------------------------------------------------------------
+# scan_transcript_stats
+# ---------------------------------------------------------------------------
+class TestScanTranscriptStats(unittest.TestCase):
+
+    def setUp(self):
+        import tempfile, pathlib, monitor
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig = monitor._CLAUDE_DIR
+        self._orig_cache = monitor._usage_cache.copy()
+        monitor._CLAUDE_DIR = pathlib.Path(self.tmpdir)
+        monitor._usage_cache.clear()
+
+    def tearDown(self):
+        import shutil, monitor
+        monitor._CLAUDE_DIR = self._orig
+        monitor._usage_cache.clear()
+        monitor._usage_cache.update(self._orig_cache)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_session(self, project, sid, lines, subagent=False):
+        import pathlib
+        if subagent:
+            d = pathlib.Path(self.tmpdir) / project / sid / "subagents"
+        else:
+            d = pathlib.Path(self.tmpdir) / project
+        d.mkdir(parents=True, exist_ok=True)
+        fn = f"agent-{sid}.jsonl" if subagent else f"{sid}.jsonl"
+        (d / fn).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def test_empty_dir(self):
+        models, ov = scan_transcript_stats("all", ttl=0)
+        self.assertEqual(models, {})
+        self.assertEqual(ov["sessions"], 0)
+
+    def test_single_session(self):
+        import json
+        lines = [
+            json.dumps({"type": "user", "timestamp": "2026-04-12T10:00:00Z"}),
+            json.dumps({
+                "type": "assistant",
+                "timestamp": "2026-04-12T10:05:00Z",
+                "message": {
+                    "model": "claude-opus-4-6",
+                    "usage": {"input_tokens": 100, "output_tokens": 200},
+                },
+            }),
+            json.dumps({
+                "type": "assistant",
+                "timestamp": "2026-04-12T10:10:00Z",
+                "message": {
+                    "model": "claude-opus-4-6",
+                    "usage": {"input_tokens": 50, "output_tokens": 80},
+                },
+            }),
+        ]
+        self._write_session("proj1", "sess1", lines)
+        models, ov = scan_transcript_stats("all", ttl=0)
+        self.assertEqual(models["claude-opus-4-6"]["input"], 150)
+        self.assertEqual(models["claude-opus-4-6"]["output"], 280)
+        self.assertEqual(models["claude-opus-4-6"]["calls"], 2)
+        self.assertEqual(ov["sessions"], 1)
+        self.assertIn("2026-04-12", ov["active_days"])
+
+    def test_subagent_excluded_from_session_count(self):
+        import json
+        main_lines = [json.dumps({
+            "type": "assistant", "timestamp": "2026-04-12T10:00:00Z",
+            "message": {"model": "claude-opus-4-6",
+                        "usage": {"input_tokens": 10, "output_tokens": 20}},
+        })]
+        sub_lines = [json.dumps({
+            "type": "assistant", "timestamp": "2026-04-12T10:01:00Z",
+            "message": {"model": "claude-haiku-4-5-20251001",
+                        "usage": {"input_tokens": 5, "output_tokens": 10}},
+        })]
+        self._write_session("proj1", "sess1", main_lines)
+        self._write_session("proj1", "sess1", sub_lines, subagent=True)
+        models, ov = scan_transcript_stats("all", ttl=0)
+        # Session count: only main session, not subagent
+        self.assertEqual(ov["sessions"], 1)
+        # But tokens from subagent are included
+        self.assertIn("claude-haiku-4-5-20251001", models)
+
+    def test_malformed_lines_skipped(self):
+        import json
+        lines = [
+            "not json at all",
+            json.dumps({
+                "type": "assistant", "timestamp": "2026-04-12T10:00:00Z",
+                "message": {"model": "claude-opus-4-6",
+                            "usage": {"input_tokens": 10, "output_tokens": 20}},
+            }),
+        ]
+        self._write_session("proj1", "sess1", lines)
+        models, ov = scan_transcript_stats("all", ttl=0)
+        self.assertEqual(models["claude-opus-4-6"]["calls"], 1)
+
+    def test_ttl_cache(self):
+        import json, monitor
+        lines = [json.dumps({
+            "type": "assistant", "timestamp": "2026-04-12T10:00:00Z",
+            "message": {"model": "claude-opus-4-6",
+                        "usage": {"input_tokens": 10, "output_tokens": 20}},
+        })]
+        self._write_session("proj1", "sess1", lines)
+        # First call populates cache
+        m1, _ = scan_transcript_stats("all", ttl=60)
+        self.assertEqual(m1["claude-opus-4-6"]["calls"], 1)
+        # Write more data
+        lines.append(json.dumps({
+            "type": "assistant", "timestamp": "2026-04-12T10:01:00Z",
+            "message": {"model": "claude-opus-4-6",
+                        "usage": {"input_tokens": 10, "output_tokens": 20}},
+        }))
+        self._write_session("proj1", "sess1", lines)
+        # Cached — should still show 1 call
+        m2, _ = scan_transcript_stats("all", ttl=60)
+        self.assertEqual(m2["claude-opus-4-6"]["calls"], 1)
+        # Force refresh
+        m3, _ = scan_transcript_stats("all", ttl=0)
+        self.assertEqual(m3["claude-opus-4-6"]["calls"], 2)
+
+    def test_daily_tokens(self):
+        import json
+        lines = [json.dumps({
+            "type": "assistant", "timestamp": "2026-04-12T10:00:00Z",
+            "message": {"model": "claude-opus-4-6",
+                        "usage": {"input_tokens": 100, "output_tokens": 200}},
+        })]
+        self._write_session("proj1", "sess1", lines)
+        _, ov = scan_transcript_stats("all", ttl=0)
+        self.assertEqual(ov["daily_tokens"].get("2026-04-12"), 300)
+
+    def test_longest_session_duration(self):
+        import json
+        lines = [
+            json.dumps({"type": "user", "timestamp": "2026-04-12T10:00:00Z"}),
+            json.dumps({
+                "type": "assistant", "timestamp": "2026-04-12T11:00:00Z",
+                "message": {"model": "claude-opus-4-6",
+                            "usage": {"input_tokens": 10, "output_tokens": 20}},
+            }),
+        ]
+        self._write_session("proj1", "sess1", lines)
+        _, ov = scan_transcript_stats("all", ttl=0)
+        # 1 hour = 3600000 ms
+        self.assertAlmostEqual(ov["longest_dur_ms"], 3600000, delta=1000)
+
+    def test_multiple_models(self):
+        import json
+        lines = [
+            json.dumps({
+                "type": "assistant", "timestamp": "2026-04-12T10:00:00Z",
+                "message": {"model": "claude-opus-4-6",
+                            "usage": {"input_tokens": 100, "output_tokens": 200}},
+            }),
+            json.dumps({
+                "type": "assistant", "timestamp": "2026-04-12T10:01:00Z",
+                "message": {"model": "claude-haiku-4-5-20251001",
+                            "usage": {"input_tokens": 50, "output_tokens": 80}},
+            }),
+        ]
+        self._write_session("proj1", "sess1", lines)
+        models, _ = scan_transcript_stats("all", ttl=0)
+        self.assertEqual(len(models), 2)
+        self.assertIn("claude-opus-4-6", models)
+        self.assertIn("claude-haiku-4-5-20251001", models)
+
+
+# ---------------------------------------------------------------------------
+# render_stats
+# ---------------------------------------------------------------------------
+class TestRenderStats(unittest.TestCase):
+
+    def setUp(self):
+        import tempfile, pathlib, monitor
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig = monitor._CLAUDE_DIR
+        self._orig_cache = monitor._usage_cache.copy()
+        monitor._CLAUDE_DIR = pathlib.Path(self.tmpdir)
+        monitor._usage_cache.clear()
+
+    def tearDown(self):
+        import shutil, monitor
+        monitor._CLAUDE_DIR = self._orig
+        monitor._usage_cache.clear()
+        monitor._usage_cache.update(self._orig_cache)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_no_data_shows_placeholder(self):
+        buf = render_stats(80, 24, "all")
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        self.assertIn("No transcript data", plain)
+
+    def test_with_data_shows_model(self):
+        import json, pathlib
+        d = pathlib.Path(self.tmpdir) / "proj1"
+        d.mkdir(parents=True)
+        lines = [json.dumps({
+            "type": "assistant", "timestamp": "2026-04-12T10:00:00Z",
+            "message": {"model": "claude-opus-4-6",
+                        "usage": {"input_tokens": 100, "output_tokens": 200}},
+        })]
+        (d / "sess1.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        buf = render_stats(80, 40, "all")
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        self.assertIn("Opus 4.6", plain)
+        self.assertIn("100.0", plain)  # 100% single model
+        self.assertIn("Total", plain)
+
+    def test_shows_overview_metrics(self):
+        import json, pathlib
+        d = pathlib.Path(self.tmpdir) / "proj1"
+        d.mkdir(parents=True)
+        lines = [json.dumps({
+            "type": "assistant", "timestamp": "2026-04-12T10:00:00Z",
+            "message": {"model": "claude-opus-4-6",
+                        "usage": {"input_tokens": 100, "output_tokens": 200}},
+        })]
+        (d / "sess1.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        buf = render_stats(80, 40, "all")
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        self.assertIn("SES", plain)
+        self.assertIn("DAY", plain)
+        self.assertIn("STK", plain)
+        self.assertIn("LSS", plain)
+
+    def test_period_labels(self):
+        buf_all = render_stats(80, 24, "all")
+        buf_7d = render_stats(80, 24, "7d")
+        buf_30d = render_stats(80, 24, "30d")
+        self.assertIn("All Time", M_ANSI_RE.sub("", "\n".join(buf_all)))
+        self.assertIn("Last 7 Days", M_ANSI_RE.sub("", "\n".join(buf_7d)))
+        self.assertIn("Last 30 Days", M_ANSI_RE.sub("", "\n".join(buf_30d)))
+
+    def test_footer_has_keys(self):
+        buf = render_stats(80, 24, "all")
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        self.assertIn("1", plain)
+        self.assertIn("2", plain)
+        self.assertIn("3", plain)
+        self.assertIn("close", plain)
+
+
+# ---------------------------------------------------------------------------
+# render_legend
+# ---------------------------------------------------------------------------
+class TestRenderLegend(unittest.TestCase):
+
+    def test_returns_buffer(self):
+        buf = render_legend(80, 24)
+        self.assertIsInstance(buf, list)
+        self.assertEqual(len(buf), 24)
+
+    def test_contains_all_metrics(self):
+        buf = render_legend(80, 40)
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        for label in ["APR", "CHR", "CTX", "5HL", "7DL", "BRN", "CTR", "CST",
+                       "TDY", "WEK", "LNS", "NOW", "UPD"]:
+            self.assertIn(label, plain)
+
+    def test_contains_usage_stats_section(self):
+        buf = render_legend(80, 40)
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        for label in ["SES", "DAY", "STK", "LSS", "TOP"]:
+            self.assertIn(label, plain)
+
+    def test_contains_keys(self):
+        buf = render_legend(80, 40)
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        for key in ["q", "r", "s", "u", "l", "1-9"]:
+            self.assertIn(key, plain)
+
+
+# ---------------------------------------------------------------------------
+# render_frame
+# ---------------------------------------------------------------------------
+class TestRenderFrame(unittest.TestCase):
+
+    def test_basic_render(self):
+        buf = render_frame(_full_data(), [], 80, 30)
+        self.assertIsInstance(buf, list)
+        self.assertEqual(len(buf), 30)
+
+    def test_stale_shows_inactive(self):
+        buf = render_frame(_full_data(), [], 80, 30, stale=True)
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        self.assertIn("Inactive", plain)
+
+    def test_legend_mode(self):
+        buf = render_frame(_full_data(), [], 80, 50, show_legend=True)
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        self.assertIn("LEGEND", plain)
+
+    def test_footer_has_usage_key(self):
+        buf = render_frame(_full_data(), [], 80, 30)
+        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        self.assertIn("[u]us", plain)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- New `[u]` key modal: per-model token breakdown (In/Out/Calls) with progress bars
- Overview metrics: SES, DAY, STK, LSS, TOP — sessions, active days, streaks, longest session, most active day
- Period filter via `[1]`/`[2]`/`[3]` keys: All Time / 7 Days / 30 Days
- Reads `~/.claude/projects/**/*.jsonl` session transcripts (read-only)
- Bug fixes: `_parse_ts` negative UTC offsets, duplicate `sid_str`/`day` calc, cache TTL `time.monotonic()`
- 39 new tests (142 → 181)
- Docs updated: README, CHANGELOG, CLAUDE.md

## Test plan
- [x] `py -m py_compile monitor.py statusline.py shared.py update.py`
- [x] `py tests.py` — 181 tests pass
- [x] Smoke test: `scan_transcript_stats()` matches CC Stats tab numbers
- [x] Manual test: `[u]` modal opens, `[1]`/`[2]`/`[3]` switch periods, any other key closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)