### PR TITLE
fix(monitor): v1.8.1 — clip fix, auto-purge 48h, BRN unit, cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.8.1 — 2026-04-13
+
+**Features:**
+- Auto-purge dead sessions — `.json` + `.jsonl` pairs older than 48h are automatically deleted from temp dir on session list refresh (`DEAD_SESSION_TTL` constant). Reserved files (`rls.json`, `stats.json`) are skipped.
+
+**Bug fixes:**
+- Fixed `_fit_buf_height` clip direction — legend/picker/stats modals now clip content from bottom (preserving header) instead of from top (losing header on small terminals)
+- Removed competitor comparison table from legend overlay (belongs in README docs, not in the TUI)
+- Fixed BRN unit inconsistency — statusline now shows `$/min` (was `$/m`), consistent with dashboard
+
+**Tests:**
+- 278 → 280: added `test_dead_session_purged_after_48h`, `test_recent_session_not_purged`
+
+**Other:**
+- VERSION bumped to `1.8.1`
+
 ## v1.8.0 — 2026-04-13
 
 **Features:**
@@ -10,7 +26,7 @@
 - Smart warnings (CTF/BRN) now blink and are visually separated from header
 - monitor.py writes `rls.json` and `stats.json` to temp dir for cross-process state sharing
 - Statusline segments streamlined: Model │ CTX │ 5HL │ 7DL │ CST │ BRN │ APR │ CHR — trailing segments drop on narrow terminals. No background padding (CC notifications share the row).
-- Legend: "WHY CC AIO MON?" competitor comparison section (claude-monitor, ccusage, ccstatusline vs CC AIO MON)
+
 
 **Bug fixes:**
 - Fixed inverted color logic in `_reset_color()` — reset countdown now shows green when close to reset (good) and red when far from reset (bad)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,7 @@
 
 ## What to keep in sync
 
-- `MAX_FILE_SIZE` is defined in both `statusline.py` and `monitor.py` — update both if you change it.
-- `calc_rates` lives in `shared.py` — imported by both `statusline.py` and `monitor.py`.
-- ANSI color palette (`C_RED`, `C_GRN`, etc.) is duplicated — keep both files consistent.
+- `shared.py` is the single source of truth for shared constants (`_SID_RE`, `_ANSI_RE`, `MAX_FILE_SIZE`, `DATA_DIR_NAME`), ANSI colors (`C_RED`, `C_GRN`, etc.), helpers (`_num`, `_sanitize`, `f_tok`, `f_cost`, `f_dur`), and `calc_rates`. Both `statusline.py` and `monitor.py` import from it.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Other monitors scrape log files or estimate costs from token counts. CC AIO MON 
 - **Responsive layout** — statusline drops right segments for narrow terminals. Dashboard compresses sections automatically.
 - **Multi-session** — auto-detects sessions via temp files. Numbered picker for multiple sessions. Press `s` to switch anytime.
 - **Stale detection** — sessions idle > 30 minutes get dimmed metrics with last known values preserved. See [Session States](#session-states) for a visual example.
+- **Auto-purge** — dead session files older than 48 hours are automatically cleaned up from the temp directory.
 - **Release check (RLS)** — background version check against GitHub once per hour. Shows green "up to date" or blinking red "update available" in the dashboard. Disable with `CC_AIO_MON_NO_UPDATE_CHECK=1`.
 - **Security hardened** — session ID regex validation (`[a-zA-Z0-9_-]{1,128}`), C0/C1 control character sanitization, atomic writes via `NamedTemporaryFile`, file size limits (1MB JSON, 10MB JSONL).
 
@@ -181,6 +182,7 @@ export CLAUDE_STATUS_CRIT=90
 - History: append-only JSONL, written only after snapshot succeeds — keeps `.json` and `.jsonl` in sync
 - Auto-trimmed when file exceeds 1 MB (keeps last 1000 entries)
 - Stale `.tmp` files older than 60 seconds cleaned up automatically
+- Dead sessions older than 48 hours auto-purged (`.json` + `.jsonl` pair deleted)
 - Session detection: files older than 30 minutes marked as stale — metrics dimmed, `Session Inactive \ (Nm)` header shown with minutes-since-last-update, last known values preserved (see [Session States](#session-states))
 
 ### Security

--- a/monitor.py
+++ b/monitor.py
@@ -290,9 +290,10 @@ SYNC_OFF = E + "?2026l"
 C_FG = E + "38;2;180;186;200m"  # monitor-only: default foreground
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
-VERSION = "1.8.0"
+VERSION = "1.8.1"
 # _SID_RE, _ANSI_RE, MAX_FILE_SIZE imported from shared.py
 STALE_THRESHOLD = 1800  # 30 min — Claude Code emits no events during idle
+DEAD_SESSION_TTL = 172800  # 48h — auto-purge dead session files from temp dir
 
 try:
     WARN_BRN = float(os.environ.get("CLAUDE_WARN_BRN", "0.50"))
@@ -432,7 +433,7 @@ def collect_warnings(data, cpm, xpm):
                 warnings.append(f"CTF <{max(1, int(eta_mins))}m")
     # BRN
     if cpm and cpm > WARN_BRN:
-        warnings.append(f"BRN {cpm:.4f}$/m")
+        warnings.append(f"BRN {cpm:.4f}$/min")
     return warnings
 
 
@@ -657,11 +658,24 @@ _RESERVED_FILES = {"rls", "stats"}  # non-session JSON files written by monitor
 def list_sessions():
     if not DATA_DIR.exists():
         return []
+    now = time.time()
     # Clean up stale .tmp files (orphans from crashed writes)
     for tmp in DATA_DIR.glob("*.tmp"):
         try:
-            if time.time() - tmp.stat().st_mtime > 60:
+            if now - tmp.stat().st_mtime > 60:
                 tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+    # Auto-purge dead sessions older than 48h (.json + .jsonl pair)
+    for f in DATA_DIR.glob("*.json"):
+        sid = f.stem
+        if sid in _RESERVED_FILES or not _SID_RE.match(sid):
+            continue
+        try:
+            if now - f.stat().st_mtime > DEAD_SESSION_TTL:
+                f.unlink(missing_ok=True)
+                hist = DATA_DIR / f"{sid}.jsonl"
+                hist.unlink(missing_ok=True)
         except OSError:
             pass
     sessions = []
@@ -676,7 +690,7 @@ def list_sessions():
             if st.st_size > MAX_FILE_SIZE:
                 continue
             mt = st.st_mtime
-            age = time.time() - mt
+            age = now - mt
             d = json.loads(f.read_text(encoding="utf-8"))
             sessions.append({
                 "id": sid, "mtime": mt, "age": age,
@@ -763,7 +777,7 @@ def spin_rls():
 
 
 def _fit_buf_height(buf, rows, *, clip_tail=False):
-    """Fit buffer to terminal height. Dashboard (clip_tail=False): protects last 2 lines (footer separator + keys). Legend/picker (clip_tail=True): clips from top."""
+    """Fit buffer to terminal height. Dashboard (clip_tail=False): protects last 2 lines (footer separator + keys). Legend/picker/stats (clip_tail=True): preserves header, clips from bottom."""
     try:
         rows = int(rows)
     except (TypeError, ValueError):
@@ -787,10 +801,7 @@ def _fit_buf_height(buf, rows, *, clip_tail=False):
         if not shrunk:
             break
     if len(buf) > sub_target:
-        if clip_tail:
-            buf[:] = buf[-sub_target:]
-        else:
-            buf[:] = buf[:sub_target]
+        buf[:] = buf[:sub_target]
     while len(buf) < sub_target:
         buf.append("")
     buf.extend(tail)
@@ -1041,13 +1052,6 @@ def render_legend(cols, rows):
     buf.append(sep(SW))
     buf.append(f"{C_DIM}Shows current vs remote version, new commits,{R}")
     buf.append(f"{C_DIM}changelog preview, safety warnings. Press a to apply.{R}")
-    buf.append("")
-    buf.append(f"{C_WHT}{B}WHY CC AIO MON?{R}")
-    buf.append(sep(SW))
-    buf.append(f"{C_DIM}claude-monitor   JSONL cost logs     Estimated, not real-time{R}")
-    buf.append(f"{C_DIM}ccusage          CLI aggregator      Historical only, no live view{R}")
-    buf.append(f"{C_DIM}ccstatusline     Status line script   No TUI, no multi-session{R}")
-    buf.append(f"{C_CYN}{B}CC AIO MON       Official stdin JSON  Real-time, stdlib only{R}")
     buf.append(sep(SW))
     buf.append(f"{C_DIM}press any key to close{R}")
 

--- a/statusline.py
+++ b/statusline.py
@@ -15,7 +15,6 @@ import json
 import os
 import pathlib
 import platform
-import re
 import struct
 import sys
 import tempfile
@@ -207,7 +206,7 @@ def seg_chr(data):
 def seg_brn(brn):
     if brn is None or brn <= 0.0001:
         return None
-    text = f"{C_ORN}BRN{R} {C_ORN}{B}{brn:.4f} $/m{R}"
+    text = f"{C_ORN}BRN{R} {C_ORN}{B}{brn:.4f} $/min{R}"
     return text, len(_ANSI_RE.sub("", text))
 
 
@@ -225,7 +224,7 @@ def seg_apr(data):
 # ---------------------------------------------------------------------------
 # Layout assembly — single line (CC notifications share the row on the right)
 # ---------------------------------------------------------------------------
-def build_line(data, cols, brn=None, ctr=None):
+def build_line(data, cols, brn=None):
     """Build single status line. Drops trailing segments when too wide."""
     sv = _SEP_VLEN
 

--- a/tests.py
+++ b/tests.py
@@ -43,8 +43,8 @@ from monitor import (
     render_picker,
 )
 from shared import (
-    MAX_FILE_SIZE, _SID_RE, _ANSI_RE, _ANSI_RE as M_ANSI_RE,
-    _sanitize, E, R, B,
+    MAX_FILE_SIZE, _ANSI_RE, _ANSI_RE as M_ANSI_RE,
+    _sanitize,
     C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM,
 )
 # M_* aliases for backward compat with existing test assertions
@@ -87,7 +87,9 @@ class TestFitBufHeight(unittest.TestCase):
         buf = [str(i) for i in range(30)]
         _fit_buf_height(buf, 10, clip_tail=True)
         self.assertEqual(len(buf), 10)
-        self.assertEqual(buf[-1], "29")
+        # Header preserved, bottom clipped
+        self.assertEqual(buf[0], "0")
+        self.assertEqual(buf[-1], "9")
 
     def test_clip_tail_rows_zero(self):
         buf = ["a", "b", "c"]
@@ -1425,7 +1427,6 @@ class TestRlsInDashboard(unittest.TestCase):
 
 import monitor as _monitor_mod
 import subprocess
-import threading
 
 
 class TestRlsCheckWorker(unittest.TestCase):
@@ -2086,7 +2087,6 @@ class TestRenderUpdateModal(unittest.TestCase):
         self.assertIn(remote_ver, plain)
 
 
-import monitor as _monitor_mod2  # noqa: F811 — second alias for new test classes
 import pathlib
 import json
 
@@ -2183,6 +2183,29 @@ class TestListSessions(unittest.TestCase):
         # mtime is now — should NOT be cleaned
         list_sessions()
         self.assertTrue(tmp_file.exists())
+
+    def test_dead_session_purged_after_48h(self):
+        import monitor
+        sid = "oldSession"
+        p = pathlib.Path(self._tmp) / f"{sid}.json"
+        h = pathlib.Path(self._tmp) / f"{sid}.jsonl"
+        p.write_text('{"model": {}}', encoding="utf-8")
+        h.write_text('{"t": 1}\n', encoding="utf-8")
+        # Set mtime to 49h ago
+        old_time = time.time() - 176400
+        os.utime(p, (old_time, old_time))
+        list_sessions()
+        self.assertFalse(p.exists())
+        self.assertFalse(h.exists())
+
+    def test_recent_session_not_purged(self):
+        import monitor
+        sid = "recentSession"
+        p = pathlib.Path(self._tmp) / f"{sid}.json"
+        p.write_text('{"model": {"display_name": "Opus"}, "session_name": "", "cwd": ""}', encoding="utf-8")
+        result = list_sessions()
+        self.assertTrue(p.exists())
+        self.assertEqual(len(result), 1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Auto-purge**: dead session files (`.json` + `.jsonl`) older than 48h auto-deleted from temp dir
- **Clip fix**: legend/picker/stats modals preserve header, clip content from bottom (was losing header)
- **BRN unit**: `$/m` → `$/min` in `collect_warnings` for consistency with dashboard
- **Cleanup**: removed dead `ctr` param, unused `import re`, stale test imports, updated CONTRIBUTING.md

## Test plan
- [x] `py -m py_compile shared.py statusline.py monitor.py update.py` — pass
- [x] `py tests.py` — 280 tests pass
- [ ] CI (Ubuntu 3.8, Ubuntu 3.12, Windows 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)