### PR TITLE
fix(monitor): v1.8.1 audit round 2 — security, dedup, CI, macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.12"]
         exclude:
           - os: windows-latest
+            python-version: "3.8"
+          - os: macos-latest
             python-version: "3.8"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,5 +29,4 @@ jobs:
         run: python -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ('shared.py','statusline.py','monitor.py','update.py')]"
       - name: Run tests
         run: python tests.py
-    # Windows tests only Python 3.12 (excluded 3.8 combo)
-    # Ubuntu tests both 3.8 and 3.12 for compat coverage
+    # Ubuntu: 3.8 + 3.12 for compat. Windows + macOS: 3.12 only (3.8 not available on runners)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,32 @@
 **Bug fixes:**
 - Fixed `_fit_buf_height` clip direction — legend/picker/stats modals now clip content from bottom (preserving header) instead of from top (losing header on small terminals)
 - Removed competitor comparison table from legend overlay (belongs in README docs, not in the TUI)
-- Fixed BRN unit inconsistency — statusline now shows `$/min` (was `$/m`), consistent with dashboard
+- Fixed BRN unit inconsistency — `$/m` → `$/min` in statusline `seg_brn` and `collect_warnings` (consistent with dashboard)
+- Fixed `f_tok` accepting negative token counts — now returns `"--"` (consistent with `f_cost`/`f_dur`)
+- Fixed `render_frame` APR not clamped to 100% (statusline was clamped, dashboard was not)
+- Fixed `DATA_DIR.mkdir()` in monitor.py missing `mode=0o700` — default permissions were world-readable on shared Unix systems
+- Added symlink check on `DATA_DIR` in `list_sessions()` — rejects symlinked data directory (statusline.py already had this)
+- Fixed stray backslash in README session detection description
+- Fixed `_rls_fetching` race condition — now uses `threading.Lock` instead of bare boolean
+
+**Refactor:**
+- `VERSION_RE` regex deduplicated into `shared.py` — used by monitor.py and update.py (was defined 3 times)
+- Removed unused imports: `E` from statusline.py, `C_WHT` and `M_*` aliases from tests.py
+- Removed stale sync comments from statusline.py and monitor.py
+- Cleaned up `_ANSI_RE`/`M_ANSI_RE` dual import in tests.py — single name throughout
+- `update.py` `apply_update()` now captures and sanitizes git output via `_sanitize()` (was printing raw)
+
+**Docs:**
+- PROMO.md: updated LOC (1700 → 2400), test count (142 → 280), "zero dependencies" → "stdlib only"
+- README: added token stats + update manager screenshots, fixed stray backslash, updated macOS CI status
+- Added orphaned `cc-aio-mon-stats.png` and `cc-aio-mon-update.png` references to README
+
+**CI:**
+- Added macOS to test matrix (`macos-latest`, Python 3.12)
 
 **Tests:**
 - 278 → 280: added `test_dead_session_purged_after_48h`, `test_recent_session_not_purged`
+- Updated `TestRlsCheckWorker` and `TestRlsMaybeCheck` for `threading.Lock` refactor
 
 **Other:**
 - VERSION bumped to `1.8.1`

--- a/PROMO.md
+++ b/PROMO.md
@@ -1,0 +1,249 @@
+# Promo — CC AIO MON
+
+## AI code reviews
+
+Projekt bol zhodnoteny tromi veducimi AI modelmi (nie nahrada za ludske review, ale dava zakladnu uroven dovery). Kazdy dostal pristup ku kompletnym zdrojovym kodom a robil hlbkovu analyzu architektury, bezpecnosti a kvality kodu.
+
+### Google Gemini Pro
+
+> "Je to vynikajuci kus inzinierstva. Ukazuje to, ze autor velmi dobre rozumie systemovemu programovaniu, I/O operaciam a nevyuziva len slepo existujuce abstrakcie."
+
+> "Majstrovske zvladnutie IPC (Medziprocesovej komunikacie): NamedTemporaryFile + os.replace(). Toto je ucebnickovy pristup pre atomicke zapisy."
+
+> "Keby takto pragmaticky a bez zbytocnych zavislosti vznikala vacsina dnesneho CLI softveru, nas ekosystem by bol ovela cistejsi."
+
+Klucove nalez: architektura, atomic writes, CONOUT$ Windows hack, synchronized output rendering, defenzivne programovanie.
+
+### xAI Grok
+
+> "10/10 pre svoju kategoriu."
+
+> "Kod je extremne cisty, dobre komentovany, konzistentny styl. Ziadne magicke cisla, vsetko konfigurovatelne cez env vars. Perfektna cross-platform podpora."
+
+> "Bezpecnost (security hardened): Session ID validacia regexom, _sanitize() odstranuje vsetky C0/C1 control charaktery, atomic writes, hard limit na velkost suborov. Ziadne subprocess, eval, os.system, ziadne nebezpecne veci."
+
+Klucove nalez: kvalita kodu, bezpecnost, porovnanie s alternativami (vyhra v kazdej kategorii).
+
+### Anthropic Claude Opus 4.6
+
+> "2400 riadkov, stdlib only, 280 testov, CI na dvoch platformach, security hardened. Za 5 dni od v1.0 po v1.6.4."
+
+Klucove nalez: identifikoval bash -c bug v Claude Code statusLine (reported upstream), nasiel duplicitne helpery a typo v testoch — jediny model ktory nasiel realne bugy v kode namiesto len chvaly.
+
+### Pouzitie v postoch (skratena verzia)
+
+**SK/CZ:**
+
+Projekt bol zhodnoteny tromi AI modelmi (Google Gemini Pro, xAI Grok, Anthropic Claude Opus) — nie nahrada za ludske review, ale vsetky potvrdili kvalitu architektury a bezpecnosti. Gemini: "vynikajuci kus inzinierstva". Grok: "10/10 pre svoju kategoriu". Claude Opus identifikoval aj realne bugy ktore ostatne modely prehliadli.
+
+**EN:**
+
+The project was evaluated by three AI models (Google Gemini Pro, xAI Grok, Anthropic Claude Opus) — not a replacement for human review, but all three confirmed architecture and security quality. Gemini: "outstanding piece of engineering." Grok: "10/10 for its category." Claude Opus was the only model that identified actual bugs rather than just praise.
+
+---
+
+## Comparison table
+
+| Tool | Real-time | Official JSON | TUI + statusline | Stdlib only | Multi-session |
+|------|-----------|---------------|-------------------|-------------|---------------|
+| **cc-aio-mon** | Yes | Yes | Yes | Yes | Yes |
+| claude-monitor | No | No (logs) | No | ? | No |
+| ccusage | No | No | No | ? | No |
+| ccstatusline | Yes | Yes | Statusline only | Yes | No |
+
+---
+
+## SK/CZ — Facebook skupiny (plain text, copy-paste ready)
+
+Ak pouzivate Claude Code CLI, mozno ste si vsimli, ze nemate realny prehlad o tom, kolko vas relacia stoji, ako rychlo sa plni kontextove okno, alebo kedy narazite na API limity.
+
+Pomocou Claude Code (Opus 4.6) som vytvoril open-source terminalovy monitor — CC AIO MON (Python, stdlib only). Bezi priamo v terminali vedla Claude Code a v realnom case ukazuje:
+
+- Context window usage (kolko tokenov zostava)
+- API rate limity (5h a 7d) s varovanim pred zablokovanim
+- Burn rate v $/min (kolko palite za minutu)
+- Cache hit rate (ci funguje prompt caching)
+- Session cost + cross-session agregacia (dnes / 7 dni)
+
+Porovnanie s alternativami:
+
+cc-aio-mon ....... real-time, oficialny JSON, TUI + statusline, stdlib only, multi-session
+claude-monitor ... nie real-time, scrape logov, bez TUI
+ccusage .......... nie real-time, bez TUI
+ccstatusline ..... real-time, len statusline, bez multi-session
+
+Technicky: Python 3.8+, stdlib only (ziadne pip balicky), 2400 riadkov, 280 testov, CI na Ubuntu + Windows. Kod som nechal zhodnotit tromi AI modelmi (Gemini Pro, Grok, Claude Opus) — vsetky potvrdili kvalitu architektury a bezpecnosti.
+
+Ziadny pip install, ziadny build step. Setup trva 2 minuty:
+
+1. git clone https://github.com/iM3SK/cc-aio-mon.git ~/.cc-aio-mon
+2. Pridajte do ~/.claude/settings.json:
+   {"statusLine":{"type":"command","command":"bash -c 'python3 ~/.cc-aio-mon/statusline.py'"}}
+3. python3 ~/.cc-aio-mon/monitor.py
+
+Aktualne hladam testerov napriec platformami — najma macOS (Terminal.app, iTerm2) a Linux (rozne terminalove emulatory). Ak narazite na problem s farbami, rozlozenim alebo klavesnicou, otvorte issue na GitHube.
+
+https://github.com/iM3SK/cc-aio-mon
+
+Screenshoty su v README. Otazky rad zodpoviem v komentaroch.
+
+---
+
+## SK/CZ — LinkedIn (markdown OK)
+
+Ak pouzivate Claude Code CLI, mozno ste si vsimli, ze nemate realny prehlad o tom, kolko vas relacia stoji, ako rychlo sa plni kontextove okno, alebo kedy narazite na API limity.
+
+Pomocou Claude Code (Opus 4.6) som vytvoril open-source terminalovy monitor — CC AIO MON (Python, stdlib only). Bezi priamo v terminali vedla Claude Code a v realnom case ukazuje:
+
+- Context window usage (kolko tokenov zostava)
+- API rate limity (5h a 7d) s varovanim pred zablokovanim
+- Burn rate v $/min (kolko palite za minutu)
+- Cache hit rate (ci funguje prompt caching)
+- Session cost + cross-session agregacia (dnes / 7 dni)
+
+Technicky: Python 3.8+, stdlib only (ziadne pip balicky), 2400 riadkov, 280 testov, CI na Ubuntu + Windows. Kod som nechal zhodnotit tromi AI modelmi (Gemini Pro, Grok, Claude Opus) — vsetky potvrdili kvalitu architektury a bezpecnosti. Ziadny pip install, ziadny build step. Clone repo, pridajte jeden JSON blok do settings.json, hotovo.
+
+Aktualne hladam testerov napriec platformami — najma macOS (Terminal.app, iTerm2) a Linux (rozne terminalove emulatory). Ak narazite na problem s farbami, rozlozenim alebo klavesnicou, otvorte issue na GitHube.
+
+https://github.com/iM3SK/cc-aio-mon
+
+Screenshoty su v README. Otazky rad zodpoviem v komentaroch.
+
+---
+
+## EN — Reddit r/Python (Showcase Weekend)
+
+**Title:** CC AIO MON — real-time terminal monitor for Claude Code CLI (stdlib only, 2400 LOC, stdlib only)
+
+Using Claude Code (Opus 4.6), I built a TUI dashboard that shows what Claude Code is doing under the hood — context window usage, API rate limits, session costs, burn rate ($/min), cache performance. All in one terminal screen.
+
+**How it works:**
+
+Claude Code pipes JSON telemetry to `statusline.py` via stdin. The script writes atomic snapshots + JSONL history to temp files. A separate `monitor.py` polls those files and renders a fullscreen dashboard. Three Python files, stdlib only.
+
+```
+Claude Code -> stdin JSON -> statusline.py -> $TMPDIR -> monitor.py -> TUI
+```
+
+**Why I built it:**
+
+Other monitors scrape log files or estimate costs from token counts. CC AIO MON reads the official Claude Code statusLine JSON protocol — the same data Claude Code uses internally. No estimation, no guessing.
+
+| Tool | Real-time | Official JSON | TUI + statusline | Stdlib only | Multi-session |
+|------|-----------|---------------|-------------------|-------------|---------------|
+| **cc-aio-mon** | Yes | Yes | Yes | Yes | Yes |
+| claude-monitor | No | No (logs) | No | ? | No |
+| ccusage | No | No | No | ? | No |
+| ccstatusline | Yes | Yes | Statusline only | Yes | No |
+
+**Tech details:**
+
+- Python 3.8+, stdlib only — no pip, no venv, no build step
+- 2400 lines across 4 files, 280 unit tests
+- Atomic writes (NamedTemporaryFile + os.replace) for IPC
+- Synchronized Output (DEC private mode 2026h) for flicker-free rendering
+- ANSI 24-bit color with Nord palette
+- Cross-platform: Windows (py launcher + ctypes/msvcrt), macOS, Linux
+- CI: GitHub Actions — tests on Ubuntu 3.8/3.12 + Windows 3.12, Bandit security scan, CodeQL, OSSF Scorecard
+- Code evaluated by three AI models (Gemini Pro, Grok, Claude Opus) — all confirmed architecture and security quality
+
+**Looking for testers:**
+
+The main gap is cross-platform terminal testing. I've tested on Windows Terminal + bash, but I need people to try it on:
+
+- macOS Terminal.app, iTerm2, Kitty, Alacritty
+- Linux — GNOME Terminal, Konsole, xfce4-terminal, tmux, screen
+- Windows — different terminal emulators, PowerShell vs bash
+
+If colors look wrong, bars are misaligned, or keyboard input doesn't work — open an issue. Setup takes 2 minutes (clone + one JSON block in settings.json).
+
+GitHub: https://github.com/iM3SK/cc-aio-mon
+
+Screenshots in the README. Happy to answer questions about the architecture.
+
+---
+
+## EN — Reddit r/ClaudeAI
+
+**Title:** I built a real-time terminal monitor for Claude Code — track context, costs, rate limits, burn rate
+
+If you use Claude Code CLI, you probably noticed there's no easy way to see how fast you're burning through context, what your session is costing you per minute, or when you're about to hit API rate limits.
+
+I built CC AIO MON using Claude Code (Opus 4.6) to solve that. It reads Claude Code's official statusLine JSON protocol via stdin and gives you:
+
+- One-line ANSI status bar (runs inside Claude Code)
+- Fullscreen TUI dashboard (runs in a separate terminal)
+- Cross-session cost tracking (today + rolling 7 days)
+- Smart warnings when context fills fast, rate limits approach, or burn rate spikes
+
+| Tool | Real-time | Official JSON | TUI + statusline | Stdlib only | Multi-session |
+|------|-----------|---------------|-------------------|-------------|---------------|
+| **cc-aio-mon** | Yes | Yes | Yes | Yes | Yes |
+| claude-monitor | No | No (logs) | No | ? | No |
+| ccusage | No | No | No | ? | No |
+| ccstatusline | Yes | Yes | Statusline only | Yes | No |
+
+Python 3.8+, stdlib only, stdlib only. Code evaluated by three AI models (Gemini Pro, Grok, Claude Opus) — all confirmed architecture and security quality. Setup is 2 minutes — clone + one JSON block in `~/.claude/settings.json`.
+
+I need testers across macOS and Linux terminals. If something looks broken — colors, layout, keyboard — please open an issue.
+
+https://github.com/iM3SK/cc-aio-mon
+
+---
+
+## EN — LinkedIn
+
+Using Claude Code (Opus 4.6), I built an open-source real-time terminal monitor for Claude Code CLI.
+
+If you work with Claude Code professionally, you know the pain: no visibility into context window usage, API rate limits, or session costs until it's too late.
+
+CC AIO MON reads Claude Code's official statusLine JSON protocol and displays everything in a compact TUI dashboard — burn rate ($/min), context consumption rate (%/min), cache performance, rate limit countdowns, cross-session cost aggregation.
+
+Technical highlights:
+- Python 3.8+, stdlib only — zero external dependencies
+- 2400 lines, 280 unit tests, CI on Ubuntu + Windows
+- Atomic IPC via temp files, security hardened (path traversal prevention, input sanitization, file size limits)
+- Nord truecolor palette, flicker-free synchronized output
+- Evaluated by three AI models (Gemini Pro, Grok, Claude Opus)
+
+Currently looking for testers across macOS and Linux terminals. The tool is stable on Windows Terminal, but needs real-world validation on iTerm2, Kitty, GNOME Terminal, and others.
+
+Two-minute setup: clone, add one JSON block to settings, run monitor.py.
+
+https://github.com/iM3SK/cc-aio-mon
+
+---
+
+## EN — X / Twitter
+
+Built with Claude Code Opus 4.6: real-time terminal monitor for Claude Code CLI.
+
+Context window, API rate limits, burn rate ($/min), cache performance — all in one TUI dashboard.
+
+Python 3.8+, stdlib only, stdlib only, 2400 LOC, 280 tests. Evaluated by Gemini Pro, Grok & Claude Opus.
+
+Looking for testers across macOS/Linux/Windows terminals.
+
+https://github.com/iM3SK/cc-aio-mon
+
+---
+
+## Kde postovat
+
+| Platforma | Jazyk | Kedy | Poznamka |
+|-----------|-------|------|----------|
+| FB — SK/CZ dev skupiny | SK | Kedykolvek | Uz si postoval starsu verziu, teraz update |
+| FB — AI skupiny SK/CZ | SK | Kedykolvek | Mensia ale zaujata cielovka |
+| Reddit r/Python | EN | Vikend (Showcase Saturday/Sunday) | Automod maze pocas tyzdna |
+| Reddit r/ClaudeAI | EN | Kedykolvek | Presna cielovka, mensia komunita |
+| Reddit r/commandline | EN | Kedykolvek | TUI enthusiasti |
+| LinkedIn | EN | Utorok-Stvrtok 8-10h CET | Profesionalny ton |
+| X / Twitter | EN | Kedykolvek | Kratky format, pridaj screenshot |
+| Hacker News (Show HN) | EN | Utorok-Stvrtok | Vysoka konkurencia ale obrovska expozicia |
+
+## Tipy
+
+- **GIF/video** — natoč 15s screen recording kde dashboard bezi nazivo pocas konverzacie (asciinema alebo OBS)
+- **Screenshot** — pridaj ku kazdemu postu, text sam o sebe nepredava TUI tool
+- **Odpoved na komentare** — bud aktivny prvu hodinu po poste, algoritmy to odmenuju
+- **Cross-post** — nepostuj vsade naraz, rozloz na 2-3 dni

--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ Other monitors scrape log files or estimate costs from token counts. CC AIO MON 
 - **Cross-session cost tracking** — TDY (today) and WEK (rolling 7-day) aggregate cost across all active Claude Code sessions.
 - **Token usage stats** — press `t` for a per-model token breakdown (In/Out/Calls), session count, active days, streaks, longest session, and most active day. Reads `~/.claude/projects/` transcripts. Filterable by All Time / Last 7 Days / Last 30 Days.
 - **Update manager** — press `u` to check for updates. Shows current vs remote version, new commits, changelog preview, and safety warnings. Press `a` to apply.
-- **Cross-platform** — Windows (Terminal, PowerShell, Git Bash), macOS (Terminal, iTerm2), Linux. CI-tested: Ubuntu (Python 3.8 + 3.12), Windows (Python 3.12). macOS: not CI-tested.
+<p align="center">
+<a href="screenshots/cc-aio-mon-stats.png"><img src="screenshots/cc-aio-mon-stats.png" alt="CC AIO MON — token usage stats modal with per-model breakdown, session count, streaks"></a>
+<a href="screenshots/cc-aio-mon-update.png"><img src="screenshots/cc-aio-mon-update.png" alt="CC AIO MON — update manager modal showing current vs remote version"></a>
+</p>
+
+- **Cross-platform** — Windows (Terminal, PowerShell, Git Bash), macOS (Terminal, iTerm2), Linux. CI-tested: Ubuntu (Python 3.8 + 3.12), Windows (Python 3.12), macOS (Python 3.12).
 - **Nord truecolor palette** — ANSI 24-bit color with semantic grouping: green = performance, cyan = context, yellow = rate limits, orange = cost/finance, red = critical.
 - **Responsive layout** — statusline drops right segments for narrow terminals. Dashboard compresses sections automatically.
 - **Multi-session** — auto-detects sessions via temp files. Numbered picker for multiple sessions. Press `s` to switch anytime.
@@ -183,7 +188,7 @@ export CLAUDE_STATUS_CRIT=90
 - Auto-trimmed when file exceeds 1 MB (keeps last 1000 entries)
 - Stale `.tmp` files older than 60 seconds cleaned up automatically
 - Dead sessions older than 48 hours auto-purged (`.json` + `.jsonl` pair deleted)
-- Session detection: files older than 30 minutes marked as stale — metrics dimmed, `Session Inactive \ (Nm)` header shown with minutes-since-last-update, last known values preserved (see [Session States](#session-states))
+- Session detection: files older than 30 minutes marked as stale — metrics dimmed, `Session Inactive (Nm)` header shown with minutes-since-last-update, last known values preserved (see [Session States](#session-states))
 
 ### Security
 

--- a/monitor.py
+++ b/monitor.py
@@ -28,7 +28,7 @@ import time
 from datetime import datetime
 
 from shared import (calc_rates, _num, _sanitize, f_tok, f_cost, f_dur,
-                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, DATA_DIR_NAME,
+                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, DATA_DIR_NAME, VERSION_RE,
                     E, R, B, C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
 
 # ---------------------------------------------------------------------------
@@ -291,7 +291,6 @@ C_FG = E + "38;2;180;186;200m"  # monitor-only: default foreground
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
 VERSION = "1.8.1"
-# _SID_RE, _ANSI_RE, MAX_FILE_SIZE imported from shared.py
 STALE_THRESHOLD = 1800  # 30 min — Claude Code emits no events during idle
 DEAD_SESSION_TTL = 172800  # 48h — auto-purge dead session files from temp dir
 
@@ -450,10 +449,11 @@ _REPO_ROOT = pathlib.Path(__file__).parent.resolve()
 _RLS_TTL = 3600  # check once per hour
 _RLS_BLINK_INTERVAL = 0.5
 _rls_cache = {"t": 0.0, "status": None, "remote_ver": None}
+_rls_lock = threading.Lock()
 _rls_fetching = False
 _rls_blink_last = 0.0
 _rls_blink_on = True
-_VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+_VERSION_RE = VERSION_RE  # alias from shared.py
 
 
 def _parse_version(ver_str):
@@ -503,9 +503,10 @@ def _rls_check_worker():
         _rls_cache.update({"t": time.monotonic(), "status": "error", "remote_ver": None})
     finally:
         _rls_fetching = False
+        _rls_lock.release()
         # Write RLS status to temp file for statusline.py
         try:
-            DATA_DIR.mkdir(exist_ok=True)
+            DATA_DIR.mkdir(mode=0o700, exist_ok=True)
             rls_file = DATA_DIR / "rls.json"
             rls_data = {"status": _rls_cache.get("status"), "remote_ver": _rls_cache.get("remote_ver")}
             fd = tempfile.NamedTemporaryFile(dir=DATA_DIR, suffix=".tmp", delete=False, mode="w", encoding="utf-8")
@@ -521,9 +522,9 @@ def _rls_maybe_check():
     global _rls_fetching
     if os.environ.get("CC_AIO_MON_NO_UPDATE_CHECK") == "1":
         return
-    if _rls_fetching:
-        return
     if time.monotonic() - _rls_cache["t"] < _RLS_TTL:
+        return
+    if not _rls_lock.acquire(blocking=False):
         return
     _rls_fetching = True
     t = threading.Thread(target=_rls_check_worker, daemon=True)
@@ -656,7 +657,7 @@ _RESERVED_FILES = {"rls", "stats"}  # non-session JSON files written by monitor
 
 
 def list_sessions():
-    if not DATA_DIR.exists():
+    if not DATA_DIR.exists() or DATA_DIR.is_symlink():
         return []
     now = time.time()
     # Clean up stale .tmp files (orphans from crashed writes)
@@ -885,7 +886,7 @@ def render_frame(data, hist, cols, rows, show_legend=False, stale=False):
 
     # ── APR — API Ratio ─────────────────────────────────────
     if dur > 0:
-        apr_pct = round(api_dur / dur * 100, 1)
+        apr_pct = min(100.0, round(api_dur / dur * 100, 1))
         buf.append(f"{c(C_GRN)}{B}APR{R} {mkbar(apr_pct, c(C_GRN))}")
         buf.append(f"    {c(C_DIM)}DUR {f_dur(dur)}{R} {C_DIM}-{R} {c(C_DIM)}API {f_dur(api_dur)}{R}")
     else:

--- a/shared.py
+++ b/shared.py
@@ -10,6 +10,7 @@ _SID_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,128}$")
 _ANSI_RE = re.compile(r"\033\[[0-9;]*[a-zA-Z]")
 MAX_FILE_SIZE = 1_048_576  # 1 MB
 DATA_DIR_NAME = "claude-aio-monitor"
+VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # ANSI — Nord truecolor (shared palette for statusline.py + monitor.py)
 E = "\033["
@@ -53,7 +54,7 @@ def f_dur(ms):
 
 def f_tok(n):
     n = _num(n, 0)
-    if n == 0:
+    if n <= 0:
         return "--"
     if n < 1000:
         return f"{int(n):,}"

--- a/statusline.py
+++ b/statusline.py
@@ -22,7 +22,7 @@ import time
 
 from shared import (calc_rates as _calc_rates, _num, _sanitize, f_tok, f_cost,
                     _SID_RE, _ANSI_RE, MAX_FILE_SIZE, DATA_DIR_NAME,
-                    E, R, B, C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
+                    R, B, C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
 
 # ---------------------------------------------------------------------------
 # Config
@@ -36,7 +36,6 @@ try:
 except (ValueError, TypeError):
     CRIT = 80
 
-# _SID_RE, _ANSI_RE, MAX_FILE_SIZE, ANSI colors — imported from shared.py
 
 
 _IS_WIN = platform.system() == "Windows"

--- a/tests.py
+++ b/tests.py
@@ -43,12 +43,9 @@ from monitor import (
     render_picker,
 )
 from shared import (
-    MAX_FILE_SIZE, _ANSI_RE, _ANSI_RE as M_ANSI_RE,
-    _sanitize,
-    C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM,
+    MAX_FILE_SIZE, _ANSI_RE, _sanitize,
+    C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_DIM,
 )
-# M_* aliases for backward compat with existing test assertions
-M_RED = C_RED; M_YEL = C_YEL; M_GRN = C_GRN; M_DIM = C_DIM; M_ORN = C_ORN
 
 from statusline import (
     _get_terminal_width,
@@ -156,35 +153,35 @@ class TestFitBufHeight(unittest.TestCase):
 class TestLimitColor(unittest.TestCase):
 
     def test_low_usage_yellow(self):
-        self.assertEqual(_limit_color(20), M_YEL)
+        self.assertEqual(_limit_color(20), C_YEL)
 
     def test_mid_usage_yellow(self):
-        self.assertEqual(_limit_color(55), M_YEL)
+        self.assertEqual(_limit_color(55), C_YEL)
 
     def test_high_usage_red(self):
-        self.assertEqual(_limit_color(85), M_RED)
+        self.assertEqual(_limit_color(85), C_RED)
 
 
 class TestResetColor(unittest.TestCase):
 
     def test_lots_of_time_red(self):
         # Reset in 4h out of 5h window = 80% remaining → red (far from reset)
-        self.assertEqual(_reset_color(time.time() + 14400, 18000), M_RED)
+        self.assertEqual(_reset_color(time.time() + 14400, 18000), C_RED)
 
     def test_some_time_yellow(self):
         # Reset in 1.5h out of 5h window = 30% remaining → yellow
-        self.assertEqual(_reset_color(time.time() + 5400, 18000), M_YEL)
+        self.assertEqual(_reset_color(time.time() + 5400, 18000), C_YEL)
 
     def test_little_time_green(self):
         # Reset in 15min out of 5h window = 5% remaining → green (close to reset)
-        self.assertEqual(_reset_color(time.time() + 900, 18000), M_GRN)
+        self.assertEqual(_reset_color(time.time() + 900, 18000), C_GRN)
 
     def test_just_reset_green(self):
         # Reset epoch in the past → just reset
-        self.assertEqual(_reset_color(time.time() - 10, 18000), M_GRN)
+        self.assertEqual(_reset_color(time.time() - 10, 18000), C_GRN)
 
     def test_no_data_dim(self):
-        self.assertEqual(_reset_color(0, 18000), M_DIM)
+        self.assertEqual(_reset_color(0, 18000), C_DIM)
 
 
 # ---------------------------------------------------------------------------
@@ -739,45 +736,45 @@ class TestMkbar(unittest.TestCase):
 
     def test_zero_percent(self):
         result = mkbar(0)
-        plain = M_ANSI_RE.sub("", result)
+        plain = _ANSI_RE.sub("", result)
         self.assertIn("0.0", plain)
         self.assertIn("[", plain)
         self.assertIn("]", plain)
 
     def test_100_percent(self):
         result = mkbar(100)
-        plain = M_ANSI_RE.sub("", result)
+        plain = _ANSI_RE.sub("", result)
         self.assertIn("100.0", plain)
 
     def test_clamps_negative(self):
         result = mkbar(-10)
-        plain = M_ANSI_RE.sub("", result)
+        plain = _ANSI_RE.sub("", result)
         self.assertIn("0.0", plain)
 
     def test_clamps_over_100(self):
         result = mkbar(150)
-        plain = M_ANSI_RE.sub("", result)
+        plain = _ANSI_RE.sub("", result)
         self.assertIn("100.0", plain)
 
     def test_green_under_50(self):
         result = mkbar(30)
-        self.assertIn(M_GRN, result)
+        self.assertIn(C_GRN, result)
 
     def test_yellow_50_79(self):
         result = mkbar(60)
-        self.assertIn(M_YEL, result)
+        self.assertIn(C_YEL, result)
 
     def test_red_over_80(self):
         result = mkbar(90)
-        self.assertIn(M_RED, result)
+        self.assertIn(C_RED, result)
 
     def test_custom_color(self):
-        result = mkbar(30, M_ORN)
-        self.assertIn(M_ORN, result)
+        result = mkbar(30, C_ORN)
+        self.assertIn(C_ORN, result)
 
     def test_visual_width(self):
         result = mkbar(50)
-        plain = M_ANSI_RE.sub("", result)
+        plain = _ANSI_RE.sub("", result)
         # [████░░░]  XX.X %  → brackets + BAR_W + space + percent
         self.assertIn("[", plain)
         self.assertIn("]", plain)
@@ -1195,7 +1192,7 @@ class TestRenderStats(unittest.TestCase):
 
     def test_no_data_shows_placeholder(self):
         buf = render_stats(80, 24, "all")
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("No transcript data", plain)
 
     def test_with_data_shows_model(self):
@@ -1209,7 +1206,7 @@ class TestRenderStats(unittest.TestCase):
         })]
         (d / "sess1.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
         buf = render_stats(80, 40, "all")
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("Opus 4.6", plain)
         self.assertIn("100.0", plain)  # 100% single model
         self.assertIn("Total", plain)
@@ -1225,7 +1222,7 @@ class TestRenderStats(unittest.TestCase):
         })]
         (d / "sess1.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
         buf = render_stats(80, 40, "all")
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("SES", plain)
         self.assertIn("DAY", plain)
         self.assertIn("STK", plain)
@@ -1235,13 +1232,13 @@ class TestRenderStats(unittest.TestCase):
         buf_all = render_stats(80, 24, "all")
         buf_7d = render_stats(80, 24, "7d")
         buf_30d = render_stats(80, 24, "30d")
-        self.assertIn("All Time", M_ANSI_RE.sub("", "\n".join(buf_all)))
-        self.assertIn("Last 7 Days", M_ANSI_RE.sub("", "\n".join(buf_7d)))
-        self.assertIn("Last 30 Days", M_ANSI_RE.sub("", "\n".join(buf_30d)))
+        self.assertIn("All Time", _ANSI_RE.sub("", "\n".join(buf_all)))
+        self.assertIn("Last 7 Days", _ANSI_RE.sub("", "\n".join(buf_7d)))
+        self.assertIn("Last 30 Days", _ANSI_RE.sub("", "\n".join(buf_30d)))
 
     def test_footer_has_keys(self):
         buf = render_stats(80, 24, "all")
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("1", plain)
         self.assertIn("2", plain)
         self.assertIn("3", plain)
@@ -1260,20 +1257,20 @@ class TestRenderLegend(unittest.TestCase):
 
     def test_contains_all_metrics(self):
         buf = render_legend(80, 60)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         for label in ["APR", "CHR", "CTX", "5HL", "7DL", "BRN", "CTR", "CST",
                        "TDY", "WEK", "LNS", "NOW", "UPD", "RLS"]:
             self.assertIn(label, plain)
 
     def test_contains_usage_stats_section(self):
         buf = render_legend(80, 60)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         for label in ["SES", "DAY", "STK", "LSS", "TOP"]:
             self.assertIn(label, plain)
 
     def test_contains_keys(self):
         buf = render_legend(80, 60)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         for key in ["q", "r", "s", "u", "l", "1-9"]:
             self.assertIn(key, plain)
 
@@ -1290,17 +1287,17 @@ class TestRenderFrame(unittest.TestCase):
 
     def test_stale_shows_inactive(self):
         buf = render_frame(_full_data(), [], 80, 30, stale=True)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("Inactive", plain)
 
     def test_legend_mode(self):
         buf = render_frame(_full_data(), [], 80, 50, show_legend=True)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("LEGEND", plain)
 
     def test_footer_has_keys(self):
         buf = render_frame(_full_data(), [], 80, 35)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("[t]tk", plain)
         self.assertIn("[u]up", plain)
 
@@ -1386,7 +1383,7 @@ class TestRlsInDashboard(unittest.TestCase):
         import monitor
         monitor._rls_cache.update({"t": time.monotonic(), "status": "ok", "remote_ver": "1.8.0"})
         buf = render_frame(_full_data(), [], 80, 35)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("RLS", plain)
         self.assertIn("Up to date", plain)
 
@@ -1396,7 +1393,7 @@ class TestRlsInDashboard(unittest.TestCase):
         monitor._rls_blink_on = True
         monitor._rls_blink_last = time.monotonic()
         buf = render_frame(_full_data(), [], 80, 35)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("RLS", plain)
         self.assertIn("v9.9.9 available", plain)
 
@@ -1404,20 +1401,20 @@ class TestRlsInDashboard(unittest.TestCase):
         import monitor
         monitor._rls_cache.update({"t": time.monotonic(), "status": "error", "remote_ver": None})
         buf = render_frame(_full_data(), [], 80, 35)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertNotIn("RLS", plain)
 
     def test_rls_checking(self):
         import monitor
         monitor._rls_cache.update({"t": time.monotonic(), "status": None, "remote_ver": None})
         buf = render_frame(_full_data(), [], 80, 35)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("RLS", plain)
         self.assertIn("Checking", plain)
 
     def test_legend_contains_rls(self):
         buf = render_legend(80, 60)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("RLS", plain)
 
 
@@ -1437,10 +1434,17 @@ class TestRlsCheckWorker(unittest.TestCase):
         self._orig_fetching = _monitor_mod._rls_fetching
         # Start each test as if fetching is in progress (worker sets it False in finally)
         _monitor_mod._rls_fetching = True
+        # Acquire lock so worker can release it (mirrors _rls_maybe_check behavior)
+        _monitor_mod._rls_lock.acquire(blocking=False)
 
     def tearDown(self):
         _rls_cache.update(self._orig_cache)
         _monitor_mod._rls_fetching = self._orig_fetching
+        # Ensure lock is released for next test
+        try:
+            _monitor_mod._rls_lock.release()
+        except RuntimeError:
+            pass
 
     def _make_run(self, fetch_rc=0, show_rc=0, show_stdout=""):
         """Return a side_effect callable for subprocess.run."""
@@ -1546,8 +1550,12 @@ class TestRlsMaybeCheck(unittest.TestCase):
         self._orig_cache = dict(_rls_cache)
         self._orig_fetching = _monitor_mod._rls_fetching
         _monitor_mod._rls_fetching = False
+        # Ensure lock is free
+        try:
+            _monitor_mod._rls_lock.release()
+        except RuntimeError:
+            pass
         # Expire the cache so TTL check would normally pass
-        # Note: t=0.0 may NOT be expired on fresh CI runners where monotonic() < _RLS_TTL
         _rls_cache.update({"t": time.monotonic() - _RLS_TTL - 1, "status": None, "remote_ver": None})
         # Remove the env var if set
         self._env_var_was_set = "CC_AIO_MON_NO_UPDATE_CHECK" in os.environ
@@ -1556,6 +1564,10 @@ class TestRlsMaybeCheck(unittest.TestCase):
     def tearDown(self):
         _rls_cache.update(self._orig_cache)
         _monitor_mod._rls_fetching = self._orig_fetching
+        try:
+            _monitor_mod._rls_lock.release()
+        except RuntimeError:
+            pass
         if self._env_var_was_set:
             os.environ["CC_AIO_MON_NO_UPDATE_CHECK"] = "1"
         else:
@@ -1572,15 +1584,14 @@ class TestRlsMaybeCheck(unittest.TestCase):
         self.assertFalse(_monitor_mod._rls_fetching)
 
     # ------------------------------------------------------------------
-    # b. _rls_fetching=True → no thread spawned
+    # b. Lock already held → no thread spawned
     # ------------------------------------------------------------------
     def test_already_fetching_skips(self):
-        _monitor_mod._rls_fetching = True
+        # Acquire lock to simulate in-progress fetch
+        _monitor_mod._rls_lock.acquire(blocking=False)
         with patch("monitor.threading.Thread") as mock_thread:
             _rls_maybe_check()
         mock_thread.assert_not_called()
-        # Still True — we didn't change it
-        self.assertTrue(_monitor_mod._rls_fetching)
 
     # ------------------------------------------------------------------
     # c. Cache TTL not expired → no thread spawned
@@ -2071,7 +2082,7 @@ class TestRenderUpdateModal(unittest.TestCase):
         import monitor
         monitor._rls_cache.update({"t": time.monotonic(), "status": "ok", "remote_ver": VERSION})
         buf = render_update_modal(80, 24)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("Up to date", plain)
 
     def test_update_available(self):
@@ -2083,7 +2094,7 @@ class TestRenderUpdateModal(unittest.TestCase):
             with patch("monitor._update_checks", return_value=[]):
                 with patch("monitor._get_remote_changelog_preview", return_value=[]):
                     buf = render_update_modal(80, 40)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn(remote_ver, plain)
 
 
@@ -2304,7 +2315,7 @@ class TestRenderPicker(unittest.TestCase):
 
     def test_empty_sessions_shows_waiting_message(self):
         buf = render_picker([], 80, 24)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("Waiting", plain)
 
     def test_non_empty_sessions_shows_session_list(self):
@@ -2318,7 +2329,7 @@ class TestRenderPicker(unittest.TestCase):
             }
         ]
         buf = render_picker(sessions, 80, 24)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("MyProject", plain)
 
     def test_returns_buffer_of_correct_length(self):
@@ -2336,7 +2347,7 @@ class TestRenderPicker(unittest.TestCase):
             }
         ]
         buf = render_picker(sessions, 80, 30)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("stale", plain)
 
     def test_live_session_shows_live_label(self):
@@ -2350,7 +2361,7 @@ class TestRenderPicker(unittest.TestCase):
             }
         ]
         buf = render_picker(sessions, 80, 30)
-        plain = M_ANSI_RE.sub("", "\n".join(buf))
+        plain = _ANSI_RE.sub("", "\n".join(buf))
         self.assertIn("live", plain)
 
 

--- a/update.py
+++ b/update.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from shared import VERSION_RE, _sanitize
 
 
 # ---------- ANSI colors (Windows VT enable) ----------
@@ -118,7 +119,7 @@ def get_local_version():
     if not monitor.exists():
         raise RuntimeError("monitor.py not found")
     content = monitor.read_text(encoding="utf-8")
-    m = re.search(r'^VERSION\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+    m = VERSION_RE.search(content)
     if not m:
         raise RuntimeError("VERSION constant not found in monitor.py")
     return m.group(1)
@@ -128,7 +129,7 @@ def get_remote_version():
     r = run_git(["show", "origin/main:monitor.py"])
     if r.returncode != 0:
         raise RuntimeError("Failed to read remote monitor.py")
-    m = re.search(r'^VERSION\s*=\s*["\']([^"\']+)["\']', r.stdout, re.MULTILINE)
+    m = VERSION_RE.search(r.stdout)
     if not m:
         raise RuntimeError("VERSION constant not found in remote monitor.py")
     return m.group(1)
@@ -165,10 +166,13 @@ def get_remote_changelog_entry(version):
 
 def apply_update():
     hdr("Applying update")
-    r = run_git(["pull", "--ff-only", "origin", "main"], capture=False)
+    r = run_git(["pull", "--ff-only", "origin", "main"])
     if r.returncode != 0:
-        err("git pull failed")
+        err(f"git pull failed: {_sanitize(r.stderr or r.stdout or 'unknown error')}")
         sys.exit(1)
+    if r.stdout.strip():
+        for line in r.stdout.strip().split("\n"):
+            note(_sanitize(line))
     ok("Pulled latest changes")
 
     try:


### PR DESCRIPTION
## Summary
Full 6-audit pass (code vs docs, dead code, security, UI, test coverage, compatibility) with all P1+P2+P3 findings resolved:

- **Security**: DATA_DIR permissions 0o700, symlink check, threading.Lock for _rls_fetching, sanitized git output
- **Bug fixes**: f_tok negative guard, APR clamp in dashboard, BRN $/min consistency
- **Refactor**: VERSION_RE dedup to shared.py, removed unused imports/aliases/comments
- **Docs**: PROMO.md counts updated, README screenshots + backslash fix
- **CI**: macOS added to test matrix

## Test plan
- [x] `py -m py_compile shared.py statusline.py monitor.py update.py` — pass
- [x] `py tests.py` — 280 tests pass
- [ ] CI (Ubuntu 3.8 + 3.12, Windows 3.12, macOS 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)