### PR TITLE
chore: add SECURITY.md + CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything
+* @iM3SK

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| < latest | ❌       |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Please report security issues via [GitHub Private Vulnerability Reporting](https://github.com/iM3SK/cc-aio-mon/security/advisories/new).
+
+You will receive a response within 72 hours. If the issue is confirmed, a fix will be released as soon as possible.
+
+## Scope
+
+This policy covers the `cc-aio-mon` monitor and all supporting scripts (`update.py`, `check-requirements.sh`, `check-requirements.ps1`).
+
+Out of scope:
+- Claude Code itself (report to Anthropic)
+- Third-party dependencies (report upstream)


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with responsible disclosure policy (private vulnerability reporting)
- Add `CODEOWNERS` — assigns @iM3SK as default reviewer

Part of GitHub account security hygiene audit.