### PR TITLE
fix(monitor): v1.8.3 — filter synthetic model, add short model IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.8.3 — 2026-04-14
+
+**Bug fixes:**
+- Fixed `<synthetic>` internal model appearing in Token Stats — these are Claude Code internal entries with 0 tokens that inflated the Calls count
+- Added short model ID mappings (`"haiku"`, `"sonnet"`, `"opus"`) to `_MODEL_NAMES` — some transcript entries use abbreviated IDs instead of full `claude-*` identifiers
+
+**Other:**
+- VERSION bumped to `1.8.3`
+
 ## v1.8.2 — 2026-04-14
 
 **Bug fixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.8.2 — 2026-04-14
+
+**Bug fixes:**
+- Fixed BRN and CST progress bar ceilings undersized for Opus 4.6 1M (Max 20 plan) — `BRN_MAX` raised from 1.0 to **2.0** $/min, `CST_MAX` raised from 50.0 to **200.0** $. Previous ceilings caused both bars to pin at 100% during normal usage on higher-tier models.
+- Fixed `WARN_BRN` default too low for higher-tier models — raised from 0.50 to **1.00** $/min. Previous threshold triggered BRN smart warning constantly on Opus 4.6 1M.
+
+**Docs:**
+- README: updated BRN range (0-2.0 $/min), CST range (0-$200), `CLAUDE_WARN_BRN` default (1.00) in Features, Metrics table, and Configuration table
+- README: added Known Limitations section — documents delayed metric refresh after context compaction (Claude Code protocol limitation)
+
+**Other:**
+- VERSION bumped to `1.8.2`
+
 ## v1.8.1 — 2026-04-13
 
 **Features:**

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Other monitors scrape log files or estimate costs from token counts. CC AIO MON 
 - **Official stdin JSON** — reads Claude Code's `statusLine` JSON protocol via stdin. No log scraping, no file watching, no API polling. Real data, real-time.
 - **Two-tier architecture** — `statusline.py` (single-line status bar, triggered per Claude Code event) + `monitor.py` (fullscreen TUI, polls temp files independently).
 - **Temp file IPC** — atomic JSON snapshots + JSONL history in `$TMPDIR/claude-aio-monitor/`. No sockets, no databases, no shared memory. Works across terminal sessions.
-- **Progress bars with fixed ranges** — BRN (0-1.0 $/min), CTR (0-5.0 %/min), CST (0-$50) plus standard 0-100% bars for APR, CHR, CTX, 5HL, 7DL.
+- **Progress bars with fixed ranges** — BRN (0-2.0 $/min), CTR (0-5.0 %/min), CST (0-$200) plus standard 0-100% bars for APR, CHR, CTX, 5HL, 7DL.
 - **Smart warnings** — header alerts when context fills in < 30 min or burn rate exceeds threshold.
 - **Cross-session cost tracking** — TDY (today) and WEK (rolling 7-day) aggregate cost across all active Claude Code sessions.
 - **Token usage stats** — press `t` for a per-model token breakdown (In/Out/Calls), session count, active days, streaks, longest session, and most active day. Reads `~/.claude/projects/` transcripts. Filterable by All Time / Last 7 Days / Last 30 Days.
@@ -84,9 +84,9 @@ Press `r` to force a refresh (resets the stale timer if new data has arrived), o
 | **CTX** | Context window usage | 0-100% | statusline + dashboard |
 | **5HL** | 5-hour rate limit usage | 0-100% | statusline + dashboard |
 | **7DL** | 7-day rate limit usage | 0-100% | statusline + dashboard |
-| **BRN** | Cost burn rate | 0-1.0 $/min | statusline + dashboard |
+| **BRN** | Cost burn rate | 0-2.0 $/min | statusline + dashboard |
 | **CTR** | Context consumption rate | 0-5.0 %/min | dashboard |
-| **CST** | Session cost | 0-$50 | statusline + dashboard |
+| **CST** | Session cost | 0-$200 | statusline + dashboard |
 | **TDY** | Today's cost (all sessions) | — | dashboard |
 | **WEK** | Rolling 7-day cost (all sessions) | — | dashboard |
 | **LNS** | Lines added / removed | — | dashboard |
@@ -170,7 +170,7 @@ Exception: 5HL/7DL labels use yellow as base color (even below 50%) to visually 
 |----------|---------|-------|-------------|
 | `CLAUDE_STATUS_WARN` | `50` | statusline | Yellow threshold (%) |
 | `CLAUDE_STATUS_CRIT` | `80` | statusline | Red threshold (%) |
-| `CLAUDE_WARN_BRN` | `0.50` | dashboard | Burn rate warning threshold ($/min) |
+| `CLAUDE_WARN_BRN` | `1.00` | dashboard | Burn rate warning threshold ($/min) |
 | `CC_AIO_MON_NO_UPDATE_CHECK` | *(unset)* | dashboard | Set to `1` to disable background release check |
 
 ```bash
@@ -214,6 +214,10 @@ export CLAUDE_STATUS_CRIT=90
 - **Claude Code CLI** with statusline support
 - **Truecolor terminal** — Windows Terminal, iTerm2, Alacritty, Kitty, or any terminal supporting ANSI 24-bit color
 - **80 columns** minimum recommended
+
+## Known Limitations
+
+- **Delayed refresh after context compaction** — when Claude Code compacts the context window, the dashboard continues showing the pre-compaction CTX value until Claude Code emits the next statusline event (typically the next assistant message). This is a Claude Code protocol limitation — `statusline.py` is only invoked on assistant messages, permission mode changes, or vim mode toggles. There is no external API to trigger a refresh on demand.
 
 ## Troubleshooting
 

--- a/monitor.py
+++ b/monitor.py
@@ -141,6 +141,8 @@ def scan_transcript_stats(period="all", ttl=30.0):
                         continue
 
                     model = msg.get("model", "unknown")
+                    if model.startswith("<") or not model:
+                        continue  # skip synthetic/internal entries
                     u = msg["usage"]
                     inp = int(_num(u.get("input_tokens", 0)))
                     out = int(_num(u.get("output_tokens", 0)))
@@ -290,7 +292,7 @@ SYNC_OFF = E + "?2026l"
 C_FG = E + "38;2;180;186;200m"  # monitor-only: default foreground
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
-VERSION = "1.8.2"
+VERSION = "1.8.3"
 STALE_THRESHOLD = 1800  # 30 min — Claude Code emits no events during idle
 DEAD_SESSION_TTL = 172800  # 48h — auto-purge dead session files from temp dir
 
@@ -1243,6 +1245,9 @@ _MODEL_NAMES = {
     "claude-opus-4-6": "Opus 4.6",
     "claude-sonnet-4-6": "Sonnet 4.6",
     "claude-haiku-4-5-20251001": "Haiku 4.5",
+    "haiku": "Haiku",
+    "sonnet": "Sonnet",
+    "opus": "Opus",
 }
 
 

--- a/monitor.py
+++ b/monitor.py
@@ -290,14 +290,14 @@ SYNC_OFF = E + "?2026l"
 C_FG = E + "38;2;180;186;200m"  # monitor-only: default foreground
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
-VERSION = "1.8.1"
+VERSION = "1.8.2"
 STALE_THRESHOLD = 1800  # 30 min — Claude Code emits no events during idle
 DEAD_SESSION_TTL = 172800  # 48h — auto-purge dead session files from temp dir
 
 try:
-    WARN_BRN = float(os.environ.get("CLAUDE_WARN_BRN", "0.50"))
+    WARN_BRN = float(os.environ.get("CLAUDE_WARN_BRN", "1.00"))
 except (ValueError, TypeError):
-    WARN_BRN = 0.50
+    WARN_BRN = 1.00
 
 
 def vlen(s):
@@ -412,9 +412,9 @@ def _reset_color(resets_epoch, window_secs):
 # ---------------------------------------------------------------------------
 # Fixed-range bar for rate/cost metrics
 # ---------------------------------------------------------------------------
-BRN_MAX = 1.0    # $/min ceiling
+BRN_MAX = 2.0    # $/min ceiling
 CTR_MAX = 5.0    # %/min ceiling
-CST_MAX = 50.0   # $ ceiling
+CST_MAX = 200.0  # $ ceiling
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Filter `<synthetic>` internal entries from Token Stats — 0-token Claude Code internal messages that inflated Calls count
- Add short model ID mappings (`haiku`, `sonnet`, `opus`) to `_MODEL_NAMES` — some transcript entries use abbreviated IDs

## Test plan

- [x] `py tests.py` — 280 tests pass
- [ ] Token Stats modal no longer shows `<synthetic>` entry
- [ ] Short model IDs display with proper labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)