### PR TITLE
docs: NOTICE + legal affiliation disclaimer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,86 @@
+CC AIO MON
+Copyright (c) 2026 CC AIO MON Contributors
+
+Licensed under the MIT License. See LICENSE file for terms.
+
+================================================================
+Affiliation Notice
+================================================================
+
+This project is an independent, community-maintained tool. It is NOT
+affiliated with, endorsed by, sponsored by, or officially supported by
+Anthropic, PBC.
+
+"Anthropic", "Claude", and "Claude Code" are trademarks of Anthropic, PBC.
+Their use in this project is nominative fair use — we refer to the products
+by their proper names in order to describe interoperability. No claim of
+ownership, endorsement, partnership, or association is made or implied.
+
+================================================================
+Provenance of Code
+================================================================
+
+All source code in this repository is original work by the project
+contributors. No source code was copied, decompiled, or derived from
+Anthropic's proprietary codebase or any other third-party proprietary
+source.
+
+The project interacts with Anthropic products exclusively through:
+
+1. Publicly documented extension points:
+   - Claude Code `statusLine` command hook — officially designed for
+     custom status bar integrations and documented at code.claude.com.
+   - User's own local transcript files in `~/.claude/projects/` —
+     the user's personal data on the user's own disk, read-only.
+
+2. Public endpoints:
+   - `status.claude.com/api/v2/summary.json` — Anthropic's public
+     Statuspage API (standard Statuspage schema), designed for public
+     consumption by status monitoring tools.
+   - `api.anthropic.com/v1/messages` — HTTPS availability probe only,
+     no authentication, no request body, no billing. Same behavior as
+     any generic network monitoring tool (e.g. Pingdom, UptimeRobot).
+     Fetched at 30-second intervals with bounded timeouts. Opt-out via
+     `CC_AIO_MON_NO_PULSE=1` environment variable.
+
+3. Public documentation:
+   - Model pricing sourced from platform.claude.com/docs/en/about-claude/pricing
+   - API schemas from official Anthropic / Claude developer documentation
+
+No reverse engineering, traffic interception, authentication bypass,
+rate-limit circumvention, or any form of unauthorized access was
+performed during development.
+
+================================================================
+No Modification of Anthropic Products
+================================================================
+
+This tool does not modify, patch, wrap, or alter Claude Code, the
+Anthropic API, or any Anthropic-operated service. It is a read-only
+observer that consumes data voluntarily exposed by the user's local
+Claude Code installation via the officially documented `statusLine`
+extension point.
+
+================================================================
+Dependencies
+================================================================
+
+This project uses only the Python standard library. No third-party
+Python packages (pip dependencies) are required or included. This
+eliminates supply-chain risk and makes every line of behavior auditable
+in the repository itself.
+
+================================================================
+Third-Party References
+================================================================
+
+The project mentions third-party names for interoperability and
+descriptive purposes only:
+
+- Anthropic, PBC — owner of Claude, Claude Code
+- Atlassian, Inc. — Statuspage API schema used by status.claude.com
+- Nord color palette (https://www.nordtheme.com/) — color scheme
+  inspiration, MIT-licensed
+- Python Software Foundation — Python language, PSF License
+
+All trademarks are the property of their respective owners.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Real-time terminal monitor for Claude Code CLI.** Track context window usage, API rate limits, session costs, burn rate, and cache performance — all in one compact TUI dashboard. Stdlib only (Python 3.8+), cross-platform.
 
+> _Independent community project. Not affiliated with or endorsed by Anthropic. See [NOTICE](NOTICE) for provenance & trademark attribution._
+
 > **How it works:** Claude Code pipes session telemetry as JSON to `statusline.py` via **stdin** after each assistant message, permission mode change, or vim mode toggle (300ms debounce). The script parses the JSON, renders a single ANSI-colored status line in the terminal, and writes the data to `$TMPDIR/claude-aio-monitor/` as atomic JSON snapshots + append-only JSONL history. A separate `monitor.py` process polls these temp files and renders a fullscreen TUI dashboard. Both scripts share `shared.py` for burn rate ($/min) and context rate (%/min) calculation. A `pulse.py` background worker probes Anthropic backend stability (`status.claude.com` status page + HTTPS endpoint) for a "safe to code / not safe to code" verdict — disable with `CC_AIO_MON_NO_PULSE=1`. **Five Python files, stdlib only, no build step.**
 
 | | |
@@ -305,6 +307,18 @@ Open an issue first for anything non-trivial so the approach can be discussed be
 ## License
 
 MIT License. See [LICENSE](LICENSE) for details.
+
+## Legal & Affiliation
+
+This project is an **independent, community-maintained tool**. It is **not affiliated with, endorsed by, sponsored by, or officially supported by Anthropic, PBC**.
+
+"Anthropic", "Claude", and "Claude Code" are trademarks of Anthropic, PBC — used here for descriptive purposes only (nominative fair use). No claim of partnership, endorsement, or association is made or implied.
+
+All source code is **original work** by the project contributors. No code was copied, decompiled, or derived from Anthropic's proprietary codebase. The tool interacts with Anthropic products exclusively through **publicly documented extension points** (Claude Code `statusLine` hook, `status.claude.com` public Statuspage API) and the user's own local files (`~/.claude/projects/` transcripts). No reverse engineering, traffic interception, authentication bypass, or rate-limit circumvention was performed.
+
+This tool **does not modify, patch, or alter** Claude Code or any Anthropic service — it is a read-only observer of data the user's own Claude Code installation voluntarily emits via its documented extension points.
+
+See [NOTICE](NOTICE) for full provenance, third-party references, and trademark attribution.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds defensive legal documentation clarifying project independence and provenance.

### What this PR adds

- **`NOTICE` file** (new) — full provenance document covering:
  - Affiliation disclaimer (not affiliated with Anthropic, PBC)
  - Trademark attribution as nominative fair use
  - Code originality statement (no copying / decompilation / derivation from Anthropic proprietary code)
  - Data source inventory (only publicly documented extension points + user's own files)
  - No reverse engineering / auth bypass / rate-limit circumvention
  - Third-party references (Anthropic, Atlassian Statuspage, Nord theme, PSF)

- **`README.md`** — two additions:
  - Short disclaimer line under the title (visible immediately)
  - Expanded "Legal & Affiliation" section before the Changelog link

### Why

Defensive posture common to open-source projects that reference commercial products by name. Establishes on-record that:

1. Project is independent community work
2. All code is original
3. Interaction with Claude Code / Anthropic services happens only through documented extension points (statusLine hook, public Statuspage API, user's own local files)
4. No reverse engineering, traffic interception, authentication bypass, or rate-limit circumvention

Same documentation pattern used by every unofficial-but-above-board tool referencing a commercial product by name.

### No functional changes

Zero code changes. Zero test changes. Pure documentation.

## Test plan

- [x] `py tests.py` — 461/461 pass (unchanged, no code touched)
- [x] NOTICE readable + renders correctly on GitHub
- [x] README top disclaimer visible in file preview
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)