### PR TITLE
fix(pulse): annotate urlopen with # nosec B310 (false positives)

### DIFF
--- a/pulse.py
+++ b/pulse.py
@@ -271,7 +271,7 @@ def _fetch_summary():
     """Fetch status.claude.com summary.json. Returns (data, error_tag)."""
     req = urllib.request.Request(SUMMARY_URL, headers={"User-Agent": USER_AGENT})
     try:
-        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # nosec B310 — SUMMARY_URL is a hardcoded HTTPS constant, no user input
             # Guard against oversized responses
             raw = resp.read(MAX_RESPONSE_BYTES + 1)
             if len(raw) > MAX_RESPONSE_BYTES:
@@ -309,7 +309,7 @@ def _ping_api():
     )
     start = time.monotonic()
     try:
-        resp = urllib.request.urlopen(req, timeout=PING_TIMEOUT)
+        resp = urllib.request.urlopen(req, timeout=PING_TIMEOUT)  # nosec B310 — PROBE_URL is a hardcoded HTTPS constant, no user input
         resp.close()
     except urllib.error.HTTPError:
         # Any HTTP status = endpoint responded (401/405/429 all fine as liveness signal)


### PR DESCRIPTION
## Summary

Annotates the two `urllib.request.urlopen()` call sites in `pulse.py` with `# nosec B310` plus justification comments. Resolves two open Bandit alerts flagged as false positives in the v1.9.0 audit.

### Why false positive

Bandit B310 warns that `urlopen` can be misused via URL scheme injection (e.g. `file://`, `ftp://`). Both call sites use **hardcoded module-level HTTPS constants** — no user input, no scheme injection possible:

- `pulse.py:274` uses `SUMMARY_URL = "https://status.claude.com/api/v2/summary.json"`
- `pulse.py:312` uses `PROBE_URL = "https://api.anthropic.com/v1/messages"`

Both URLs are fixed, HTTPS-only, and defined as module constants at the top of the file. There is no attacker-controlled path to scheme manipulation.

### What changes

Inline comment only. Zero behavioral change. Scanner recognizes `# nosec B310` and skips the warning on subsequent scans.

## Test plan

- [x] `py tests.py` — 461/461 pass
- [x] `py -m py_compile pulse.py`
- [x] Bandit local run still reports other checks correctly (no side effects of the annotation)
- [ ] CI passes
- [ ] Next Bandit scan after merge auto-closes the two open B310 alerts on the main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)