### PR TITLE
docs: sync CI matrix description with v1.9.1 expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Other monitors scrape log files or estimate costs from token counts. CC AIO MON 
 <a href="screenshots/cc-aio-mon-update.png"><img src="screenshots/cc-aio-mon-update.png" alt="CC AIO MON — update manager showing current vs remote version, freshness timestamp, GitHub repo link, and apply option"></a>
 </p>
 
-- **Cross-platform** — Windows (Terminal, PowerShell, Git Bash), macOS (Terminal, iTerm2), Linux. CI-tested: Ubuntu (Python 3.8 + 3.12), Windows (Python 3.12), macOS (Python 3.12).
+- **Cross-platform** — Windows (Terminal, PowerShell, Git Bash), macOS (Terminal, iTerm2), Linux. CI-tested: Ubuntu (Python 3.8, 3.10, 3.11, 3.12), Windows (Python 3.12), macOS (Python 3.12).
 - **Nord truecolor palette** — ANSI 24-bit color with semantic grouping: green = performance, cyan = context, yellow = rate limits, orange = cost/finance, red = critical.
 - **Responsive layout** — statusline drops right segments for narrow terminals. Dashboard compresses sections automatically.
 - **Multi-session** — auto-detects sessions via temp files. Numbered picker for multiple sessions. Press `s` to switch anytime.

--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -126,4 +126,4 @@ CC_AIO_MON_NO_PULSE=1 python3 monitor.py
 
 ## CI status
 
-CC AIO MON is CI-tested on **Ubuntu** with **Python 3.8 and 3.12**.
+CC AIO MON is CI-tested on **Ubuntu** with **Python 3.8, 3.10, 3.11, and 3.12**.

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -141,4 +141,4 @@ py monitor.py
 
 ## CI status
 
-CC AIO MON is CI-tested on Windows with **Python 3.12** (Ubuntu tests both 3.8 and 3.12). Python 3.8 on Windows is not CI-tested.
+CC AIO MON is CI-tested on Windows with **Python 3.12** (Ubuntu tests 3.8, 3.10, 3.11, 3.12). Python 3.8 on Windows is not CI-tested.


### PR DESCRIPTION
## Summary

Three single-line doc updates. No behavior change, no code touched.

- `README.md:66` — CI matrix listing
- `docs/setup-linux.md:129` — Ubuntu CI coverage
- `docs/setup-windows.md:144` — inline Ubuntu matrix note

v1.9.1 expanded the CI matrix from `3.8 + 3.12` to `3.8, 3.10, 3.11, 3.12` on Ubuntu, but the user-facing docs still named only 3.8 + 3.12. This patch syncs the descriptions.

## Test plan

- [x] Docs-only change; no tests need rerunning
- [ ] CI checks pass (Tests/Bandit/Scorecard/CodeQL — should be trivially green on docs-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)