### PR TITLE
feat(statusline): show reset time in 5HL/7DL segments

### DIFF
--- a/statusline.py
+++ b/statusline.py
@@ -157,10 +157,14 @@ def seg_5hl(data):
         return None
     pct = round(_num(fh.get("used_percentage")))
     resets = _num(fh.get("resets_at"), 0)
-    if resets > 0 and resets < time.time():
+    now = time.time()
+    if resets > 0 and resets < now:
         pct = 0
     c = cpc_base(pct, C_YEL)
-    text = f"{c}{B}5HL{R} {c}{pct}%{R}"
+    reset_str = ""
+    if resets > now:
+        reset_str = f" {C_DIM}→{R}{c}{time.strftime('%H:%M', time.localtime(resets))}{R}"
+    text = f"{c}{B}5HL{R} {c}{pct}%{R}{reset_str}"
     return text, len(_ANSI_RE.sub("", text))
 
 
@@ -173,10 +177,14 @@ def seg_7dl(data):
         return None
     pct = round(_num(sd.get("used_percentage")))
     resets = _num(sd.get("resets_at"), 0)
-    if resets > 0 and resets < time.time():
+    now = time.time()
+    if resets > 0 and resets < now:
         pct = 0
     c = cpc_base(pct, C_YEL)
-    text = f"{c}{B}7DL{R} {c}{pct}%{R}"
+    reset_str = ""
+    if resets > now:
+        reset_str = f" {C_DIM}→{R}{c}{time.strftime('%d.%m. %H:%M', time.localtime(resets))}{R}"
+    text = f"{c}{B}7DL{R} {c}{pct}%{R}{reset_str}"
     return text, len(_ANSI_RE.sub("", text))
 
 


### PR DESCRIPTION
## What

Show the local reset time next to the usage % in the 5HL and 7DL rate-limit segments:

```
5HL 42% →18:35   7DL 30% →24.04. 12:57
```

## Why

The usage % alone doesn't tell you *when* the window resets. Knowing the exact reset time lets you decide whether to keep working or pause — especially useful when you're close to the limit.

## Details

- **5HL** — appends `→HH:MM` (local time, 24 h) when `resets_at` is in the future
- **7DL** — appends `→DD.MM. HH:MM` (date included because the reset can be days away)
- No change to existing behaviour when the window has already expired (`resets_at` in the past → `pct` falls back to 0 as before, no time shown)
- Segment width grows by ~8–12 chars; the existing right-drop logic in `build_line` handles narrow terminals automatically
- Stdlib only, no new dependencies

## Testing

```bash
NOW=$(date +%s)
echo '{"session_id":"testabc","model":{"display_name":"Sonnet 4.6"},"context_window":{"used_percentage":10,"context_window_size":200000},"rate_limits":{"five_hour":{"used_percentage":42,"resets_at":'$((NOW+7200))'},"seven_day":{"used_percentage":30,"resets_at":'$((NOW+500000))'}}}' \
  | python3 statusline.py
```