### PR TITLE
docs(changelog): note statusline screenshot regen in v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 **Docs:**
 - README metrics table, statusline description, and architecture notes updated to reflect the new segment list and the dashboard-only status of APR/CHR.
 - `.claude/CLAUDE.md` architecture section updated.
+- `screenshots/cc-aio-mon-statusline.png` regenerated to show the v1.10.0 layout (reset countdown visible, APR/CHR removed).
 
 ## v1.9.1 — 2026-04-17
 


### PR DESCRIPTION
Audit flagged that the CHANGELOG v1.10.0 `Docs` section didn't mention the regenerated statusline screenshot. The screenshot itself was regenerated in the same squash commit (1ff507c) but the bullet was missing.

One-line fix in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)