### PR TITLE
fix(security): v1.10.2 — deep security scan follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v1.10.2 — 2026-04-18
+
+Follow-up security hardening from a deep security scan of v1.10.1. All 6 findings addressed (0 critical, 0 high, 0 medium, 4 low, 2 info). Verdict of the scan was **clean (minor findings only)** — this release tightens the last remaining consistency gaps.
+
+**Security:**
+- **(L-1)** Two more TOCTOU windows closed. `calc_cross_session_costs()` (`monitor.py:573`) and `_trim_history()` (`statusline.py:360`) now route their file reads through the new `shared.safe_read()` helper — a single bounded-read primitive that caps at `N + 1` bytes and rejects overflows. Closes the `stat()`→`read_text()` race that an attacker with write access to `$TMPDIR/claude-aio-monitor/` could previously exploit for same-user RAM DoS.
+- **(L-2)** `monitor.py:2094` CLI path — `--session <evil>` with an invalid SID previously echoed the raw input back in `print(f"Invalid session ID: {sid}")`. Now passes through `_sanitize(sid)[:64]`, closing an ANSI-escape injection vector (threat model: local, low severity).
+- **(L-3)** `pulse.py:436, 467` — both `cleanup_log_startup()` and `_maybe_rotate_log()` now read `pulse.jsonl` through `safe_read()` with a hard ceiling of `LOG_MAX_BYTES * 2` (2 MB). A malicious caller that wrote >>1 MB in a single line between rotations would previously have forced Python to allocate the whole file before parsing.
+- **(L-4)** `update.py:189` — `new_ver` from `get_local_version()` is now `_sanitize()`-wrapped before the `New VERSION:` echo. `VERSION_RE` matches `[^"']+`, so an on-disk `monitor.py` modification between `git pull` and re-read could have landed ANSI escapes in the version string.
+
+**Maintainability (consistency):**
+- **(I-1)** `VERSION` is now a single source of truth in `shared.py`. `monitor.py` and `pulse.py` both import it, so `pulse.USER_AGENT` now always tracks the current release (previously pinned to `1.9.1` despite the app being on `1.10.1`). Comment in `pulse.py` explicitly cites the shared origin.
+- **(I-2)** `PY_FILES` (tuple of all 5 source files) extracted to `shared.py`. The post-update syntax-check paths in both `monitor.py:_apply_update_worker` (1669) and `update.py:apply_update` (194) now iterate `for f in PY_FILES`. `pulse.py` had previously been omitted from the monitor-side check — that drift can no longer happen.
+
+**New helper:**
+- `shared.safe_read(path, max_bytes)` — bounded read primitive. Returns `bytes` or `None` (on OSError / missing file / over-cap overflow). Centralises the `open(…,"rb").read(N+1)` idiom that appeared in 4 call sites. Future file reads should use this instead of `read_text()` or `read_bytes()` unless the caller genuinely cannot express a byte ceiling.
+
+**Tests:**
+- Added 12 regression tests across `TestSafeRead`, `TestVersionSingleSourceOfTruth`, `TestPyFilesSingleSourceOfTruth`, `TestInvalidSessionIdSanitized`, `TestApplyUpdateNewVersionSanitized`. The `test_pulse_in_syntax_check_list` regression was updated to check `shared.PY_FILES` membership instead of literal `"pulse.py"` in `update.py` source.
+- Full suite: 486 tests, all passing (one skipped on Windows — the Unix-only SIGPIPE test).
+
+**Not fixed (out of scope):**
+- Scan recommendation #4 (`GIT_CONFIG_NOSYSTEM=1` / `GIT_CONFIG_GLOBAL=/dev/null` in `_git_env()`) — defense-in-depth over already-hardcoded arg lists. Deferred as a stretch goal; current `run_git` already blocks proxy / SSH / LD_PRELOAD injection.
+
 ## v1.10.1 — 2026-04-18
 
 Security + correctness hardening from a post-v1.10.0 deep audit (16 findings total; 11 fixed, 5 accepted as intentional or out-of-scope).

--- a/monitor.py
+++ b/monitor.py
@@ -29,10 +29,10 @@ import time
 from collections import OrderedDict
 from datetime import datetime
 
-from shared import (calc_rates, _num, _sanitize, f_tok, f_cost, f_dur, f_cd,
+from shared import (calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_dur, f_cd,
                     char_width, is_safe_dir, run_git,
                     _SID_RE, _ANSI_RE, MAX_FILE_SIZE, TRANSCRIPT_MAX_BYTES,
-                    DATA_DIR, VERSION_RE,
+                    DATA_DIR, VERSION_RE, VERSION, PY_FILES,
                     RESERVED_SIDS, strip_context_suffix, compact_context_suffix,
                     extract_changelog_entry,
                     E, R, B, C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
@@ -313,7 +313,7 @@ SYNC_OFF = E + "?2026l"
 C_FG = E + "38;2;180;186;200m"  # monitor-only: default foreground
 BG_BAR = E + "48;2;46;52;64m"  # Nord polar night — header/bar background
 
-VERSION = "1.10.1"
+# VERSION is imported from shared.py — single source of truth (shared.VERSION)
 STALE_THRESHOLD = 1800  # 30 min — Claude Code emits no events during idle
 DEAD_SESSION_TTL = 172800  # 48h — auto-purge dead session files from temp dir
 
@@ -569,12 +569,19 @@ def calc_cross_session_costs():
             continue
         if sid in RESERVED_SIDS:
             continue
+        # Bounded read — stat check + safe_read cap closes TOCTOU window
         try:
             st = jl.stat()
             if st.st_size > MAX_FILE_SIZE * 10:
                 continue
-            raw = jl.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        except OSError:
+            continue
+        raw_bytes = safe_read(jl, MAX_FILE_SIZE * 10)
+        if raw_bytes is None:
+            continue
+        try:
+            raw = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError:
             continue
         entries = []
         for ln in raw.splitlines():
@@ -1657,9 +1664,10 @@ def _apply_update_worker():
     try:
         rc, out, err = _git_cmd(["pull", "--ff-only", "origin", "main"], timeout=30)
         if rc == 0:
-            # Syntax check via compile() — avoids interpreter version mismatch
+            # Syntax check via compile() — avoids interpreter version mismatch.
+            # Uses shared.PY_FILES so update.py and this worker cover the same set.
             bad = []
-            for f in ["monitor.py", "statusline.py", "shared.py", "update.py"]:
+            for f in PY_FILES:
                 fp = _REPO_ROOT / f
                 if fp.exists():
                     try:
@@ -2084,7 +2092,9 @@ def main():
 
     sid = args.session
     if sid and not _SID_RE.match(sid):
-        print(f"Invalid session ID: {sid}")
+        # sid failed regex — could contain ANSI escapes / control chars.
+        # Sanitize + length-cap before echoing to terminal.
+        print(f"Invalid session ID: {_sanitize(sid)[:64]}")
         return
     show_legend = False
     show_menu = False

--- a/pulse.py
+++ b/pulse.py
@@ -39,7 +39,7 @@ import urllib.error
 import urllib.request
 from collections import deque
 
-from shared import DATA_DIR, ensure_data_dir
+from shared import DATA_DIR, ensure_data_dir, safe_read, VERSION
 
 # ---------------------------------------------------------------------------
 # Config
@@ -49,7 +49,7 @@ PROBE_URL = "https://api.anthropic.com/v1/messages"  # expect 401/405 without au
 HTTP_TIMEOUT = 5.0
 PING_TIMEOUT = 4.0  # covers TLS handshake + HTTP round-trip
 FETCH_INTERVAL = 30.0  # seconds between background fetches
-USER_AGENT = "cc-aio-mon-pulse/1.9.1 (+https://github.com/iM3SK/cc-aio-mon)"  # keep in sync with monitor.VERSION
+USER_AGENT = f"cc-aio-mon-pulse/{VERSION} (+https://github.com/iM3SK/cc-aio-mon)"  # VERSION from shared.py
 MAX_RESPONSE_BYTES = 512 * 1024  # 512 KB cap on status.json response
 
 # Persistence + cleanup
@@ -431,19 +431,19 @@ def cleanup_log_startup():
     except OSError:
         return
     cutoff = time.time() - LOG_AGE_CUTOFF
-    kept = []
-    try:
-        with open(LOG_PATH, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    rec = json.loads(line)
-                except ValueError:
-                    continue  # drop malformed
-                ts = rec.get("ts", 0)
-                if isinstance(ts, (int, float)) and ts >= cutoff:
-                    kept.append(line if line.endswith("\n") else line + "\n")
-    except OSError:
+    # Bounded read — hard ceiling 2× LOG_MAX_BYTES protects against malicious growth
+    raw = safe_read(LOG_PATH, LOG_MAX_BYTES * 2)
+    if raw is None:
         return
+    kept = []
+    for line in raw.decode("utf-8", errors="replace").splitlines():
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue  # drop malformed
+        ts = rec.get("ts", 0)
+        if isinstance(ts, (int, float)) and ts >= cutoff:
+            kept.append(line + "\n")
     if len(kept) > LOG_STARTUP_CAP:
         kept = kept[-LOG_STARTUP_CAP:]
     with _log_lock:
@@ -463,11 +463,11 @@ def _maybe_rotate_log():
     if size <= LOG_MAX_BYTES:
         return
     with _log_lock:
-        try:
-            with open(LOG_PATH, encoding="utf-8") as f:
-                lines = f.readlines()
-        except OSError:
+        # Bounded read — hard ceiling 2× LOG_MAX_BYTES, even if file grew between stat and read
+        raw = safe_read(LOG_PATH, LOG_MAX_BYTES * 2)
+        if raw is None:
             return
+        lines = [ln + "\n" for ln in raw.decode("utf-8", errors="replace").splitlines()]
         trimmed = lines[-LOG_TRIM_TARGET:]
         _atomic_replace_log(trimmed)
 

--- a/shared.py
+++ b/shared.py
@@ -30,6 +30,13 @@ DATA_DIR_NAME = "claude-aio-monitor"
 DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
+# Single source of truth for app version — imported by monitor.py, pulse.py, update.py
+VERSION = "1.10.2"
+
+# Python files that ship with the app — used by syntax-check paths in update flow
+# (monitor.py:_apply_update_worker + update.py:apply_update). Must stay in sync.
+PY_FILES = ("monitor.py", "statusline.py", "shared.py", "pulse.py", "update.py")
+
 # ANSI — Nord truecolor (shared palette for statusline.py + monitor.py)
 E = "\033["
 R = E + "0m"
@@ -62,6 +69,23 @@ def _num(v, default=0):
         return float(v) if v is not None else default
     except (TypeError, ValueError):
         return default
+
+
+def safe_read(path, max_bytes):
+    """Bounded read — returns bytes or None. Never reads more than max_bytes + 1.
+
+    Closes TOCTOU gap: caller doesn't have to stat first, and even if they do,
+    an attacker growing the file between stat and read cannot exceed max_bytes.
+    Returns None on OSError, on >max_bytes overflow, or on missing file.
+    """
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read(max_bytes + 1)
+    except OSError:
+        return None
+    if len(raw) > max_bytes:
+        return None
+    return raw
 
 
 def _sanitize(s):

--- a/statusline.py
+++ b/statusline.py
@@ -21,7 +21,7 @@ import sys
 import tempfile
 import time
 
-from shared import (calc_rates as _calc_rates, _num, _sanitize, f_tok, f_cost, f_cd,
+from shared import (calc_rates as _calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_cd,
                     is_safe_dir, ensure_data_dir,
                     _SID_RE, _ANSI_RE, MAX_FILE_SIZE, DATA_DIR, RESERVED_SIDS,
                     strip_context_suffix,
@@ -359,8 +359,12 @@ def write_shared_state(data: dict):
 
 def _trim_history(path: pathlib.Path):
     fd = None
+    # Bounded read — JSONL trim cap is MAX_FILE_SIZE * 2 (spec line in CLAUDE.md)
+    raw = safe_read(path, MAX_FILE_SIZE * 2)
+    if raw is None:
+        return
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        lines = raw.decode("utf-8", errors="replace").splitlines()
         if len(lines) > HISTORY_TRIM_TO:
             trimmed = "\n".join(lines[-HISTORY_TRIM_TO:]) + "\n"
             fd = tempfile.NamedTemporaryFile(

--- a/tests.py
+++ b/tests.py
@@ -2583,9 +2583,10 @@ class TestUpdateApplyRollbackTag(unittest.TestCase):
 
     def test_pulse_in_syntax_check_list(self):
         # Regression: pulse.py was missing from the post-pull compile check.
-        import update as _up
-        src = pathlib.Path(_up.__file__).read_text(encoding="utf-8")
-        self.assertIn('"pulse.py"', src, "pulse.py must be in py_files syntax check list")
+        # As of v1.10.2 the file list lives in shared.PY_FILES (source of truth
+        # shared by update.py and monitor.py:_apply_update_worker).
+        self.assertIn("pulse.py", shared.PY_FILES,
+                      "pulse.py must be in shared.PY_FILES syntax check list")
 
     def test_rollback_tag_format(self):
         # Tag uses pre-update-YYYYMMDD-HHMMSS
@@ -4666,6 +4667,114 @@ class TestApplyUpdateWorkerVersionErrorSanitized(unittest.TestCase):
                                  "ANSI escape must be stripped from exception text")
                 self.assertIn("INJECTED", printed,
                               "Regular text content should pass through _sanitize")
+
+
+# ---------------------------------------------------------------------------
+# v1.10.2 security scan regression tests (L-1..L-4, I-1, I-2)
+# ---------------------------------------------------------------------------
+class TestSafeRead(unittest.TestCase):
+    """shared.safe_read: bounded file read. Core of v1.10.2 TOCTOU hardening."""
+
+    def test_returns_bytes_on_small_file(self):
+        with tempfile.NamedTemporaryFile(delete=False, mode="wb") as f:
+            f.write(b"hello")
+            p = f.name
+        try:
+            self.assertEqual(shared.safe_read(p, 100), b"hello")
+        finally:
+            os.unlink(p)
+
+    def test_returns_none_when_over_cap(self):
+        with tempfile.NamedTemporaryFile(delete=False, mode="wb") as f:
+            f.write(b"x" * 100)
+            p = f.name
+        try:
+            # Cap 50, file has 100 bytes → must return None
+            self.assertIsNone(shared.safe_read(p, 50))
+        finally:
+            os.unlink(p)
+
+    def test_returns_none_on_missing_file(self):
+        self.assertIsNone(shared.safe_read("/nonexistent/path/xyz", 100))
+
+    def test_reads_exactly_at_cap(self):
+        with tempfile.NamedTemporaryFile(delete=False, mode="wb") as f:
+            f.write(b"x" * 100)
+            p = f.name
+        try:
+            # Cap exactly matches size → pass
+            self.assertEqual(shared.safe_read(p, 100), b"x" * 100)
+        finally:
+            os.unlink(p)
+
+
+class TestVersionSingleSourceOfTruth(unittest.TestCase):
+    """I-1: VERSION lives in shared.py; monitor + pulse import from there."""
+
+    def test_shared_version_is_string(self):
+        self.assertIsInstance(shared.VERSION, str)
+        self.assertRegex(shared.VERSION, r"^\d+\.\d+\.\d+$")
+
+    def test_monitor_version_matches_shared(self):
+        import monitor as _m
+        self.assertEqual(_m.VERSION, shared.VERSION)
+
+    def test_pulse_user_agent_uses_shared_version(self):
+        import pulse as _p
+        self.assertIn(shared.VERSION, _p.USER_AGENT,
+                      f"pulse.USER_AGENT must embed shared.VERSION, got {_p.USER_AGENT!r}")
+
+
+class TestPyFilesSingleSourceOfTruth(unittest.TestCase):
+    """I-2: PY_FILES in shared.py is the single source of truth for syntax-check list."""
+
+    def test_shared_py_files_contains_all_modules(self):
+        expected = {"monitor.py", "statusline.py", "shared.py", "pulse.py", "update.py"}
+        self.assertEqual(set(shared.PY_FILES), expected)
+
+    def test_update_uses_shared_py_files(self):
+        import update as _u
+        src = pathlib.Path(_u.__file__).read_text(encoding="utf-8")
+        # Must import PY_FILES from shared and iterate via it — not hardcoded list
+        self.assertIn("PY_FILES", src)
+        self.assertIn("for f in PY_FILES", src)
+
+    def test_monitor_uses_shared_py_files(self):
+        import monitor as _m
+        src = pathlib.Path(_m.__file__).read_text(encoding="utf-8")
+        self.assertIn("PY_FILES", src)
+        self.assertIn("for f in PY_FILES", src)
+
+
+class TestInvalidSessionIdSanitized(unittest.TestCase):
+    """L-2: CLI --session error path must sanitize before echoing to terminal."""
+
+    def test_source_wraps_sid_in_sanitize(self):
+        # Running main() with evil stdin requires full TTY mock; simpler to pin
+        # the shape of the fix: the 'Invalid session ID' print site must call
+        # _sanitize(sid) before interpolating.
+        import monitor as _m
+        src = pathlib.Path(_m.__file__).read_text(encoding="utf-8")
+        # Find the print line and check it sanitizes
+        idx = src.find("Invalid session ID:")
+        self.assertGreater(idx, -1, "Invalid session ID print site missing")
+        snippet = src[idx:idx + 120]
+        self.assertIn("_sanitize(sid)", snippet,
+                      "'Invalid session ID' print must pass sid through _sanitize")
+
+
+class TestApplyUpdateNewVersionSanitized(unittest.TestCase):
+    """L-4: new_ver from get_local_version() must be sanitized before echo."""
+
+    def test_new_version_is_sanitized(self):
+        # VERSION_RE matches [^"']+ — an attacker could land an ANSI-bearing
+        # VERSION value on-disk between git pull and re-read. apply_update
+        # must _sanitize(new_ver) before printing.
+        import update as _u
+        src = pathlib.Path(_u.__file__).read_text(encoding="utf-8")
+        # Look for the sanitize wrapper around new_ver in the success branch
+        self.assertIn('_sanitize(new_ver)', src,
+                      "apply_update must sanitize new_ver before 'New VERSION:' echo")
 
 
 if __name__ == "__main__":

--- a/update.py
+++ b/update.py
@@ -16,7 +16,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from shared import VERSION_RE, _sanitize, run_git as _shared_run_git, extract_changelog_entry
+from shared import VERSION_RE, _sanitize, run_git as _shared_run_git, extract_changelog_entry, PY_FILES
 
 
 # ---------- ANSI colors (Windows VT enable) ----------
@@ -186,14 +186,16 @@ def apply_update():
 
     try:
         new_ver = get_local_version()
-        ok(f"New VERSION: {new_ver}")
+        # VERSION_RE matches [^"']+ — on-disk monitor.py could carry ANSI;
+        # sanitize before echoing to terminal.
+        ok(f"New VERSION: {_sanitize(new_ver)}")
     except Exception as e:
         warn(f"Could not verify new VERSION: {_sanitize(str(e))}")
 
-    # Syntax check — catch broken updates before user runs monitor
-    py_files = ["monitor.py", "statusline.py", "shared.py", "pulse.py", "update.py"]
+    # Syntax check — catch broken updates before user runs monitor.
+    # File list comes from shared.PY_FILES (single source of truth).
     bad = []
-    for f in py_files:
+    for f in PY_FILES:
         fp = REPO_ROOT / f
         if fp.exists():
             try:
@@ -204,7 +206,7 @@ def apply_update():
         warn(f"Syntax errors in: {', '.join(bad)} — update may be broken")
         note(f"Revert with: git reset --hard {rollback_tag}")
     else:
-        ok(f"Syntax check passed ({len(py_files)} files)")
+        ok(f"Syntax check passed ({len(PY_FILES)} files)")
 
     print()
     print(f"{GRN}Update complete.{R}")


### PR DESCRIPTION
## Summary

Follow-up to the post-v1.10.1 **deep security scan** (verdict: clean / minor findings only — 0 critical, 0 high, 0 medium, 4 low, 2 info). This PR addresses all 6 findings.

### Security (4 fixes)

- **L-1** `monitor.py:573` + `statusline.py:360` — two more `stat()`→`read_text()` TOCTOU windows closed. Both paths now go through the new `shared.safe_read()` helper which caps at `N + 1` bytes and rejects overflow. Closes the same-user RAM DoS window an attacker with write access to `$TMPDIR/claude-aio-monitor/` could exploit.
- **L-2** `monitor.py:2094` — `--session <evil>` previously echoed the raw SID in `print(f"Invalid session ID: {sid}")`. Now `_sanitize(sid)[:64]`. ANSI escape injection vector (local, low).
- **L-3** `pulse.py:436, 467` — `cleanup_log_startup()` and `_maybe_rotate_log()` now bound their log reads at `LOG_MAX_BYTES * 2` via `safe_read`. A single oversized line (no newline) could previously have forced whole-file allocation.
- **L-4** `update.py:189` — `new_ver` from `get_local_version()` is now `_sanitize()`-wrapped before the `New VERSION:` echo. `VERSION_RE` matches `[^"']+`, so an on-disk `monitor.py` mod between `git pull` and re-read could have injected ANSI.

### Maintainability (2 fixes — version / file-list drift)

- **I-1** `VERSION` moved to `shared.py` as the single source of truth. `monitor.py` and `pulse.py` both import it. `pulse.USER_AGENT` was stuck at `1.9.1` despite the app being on `1.10.1` — this can no longer drift.
- **I-2** `PY_FILES` tuple extracted to `shared.py`. Both the monitor-side and update-side syntax-check loops (`monitor.py:1669`, `update.py:194`) now iterate the shared constant. `pulse.py` had been omitted from the monitor side — that can no longer happen.

### New helper

`shared.safe_read(path, max_bytes) → bytes | None`. Returns `None` on OSError, missing file, or over-cap overflow. Centralises the `open(…,"rb").read(N+1) + length check` idiom that now covers 4 call sites.

### Not fixed (out of scope)

Scan recommendation #4 (`GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL=/dev/null` in `_git_env()`) — defense-in-depth over already-hardcoded arg lists. Deferred as stretch goal.

## Test plan

- [x] `py -m py_compile monitor.py statusline.py shared.py update.py pulse.py tests.py` — clean
- [x] `py tests.py` — **486 pass** (+12 regression: `TestSafeRead`, `TestVersionSingleSourceOfTruth`, `TestPyFilesSingleSourceOfTruth`, `TestInvalidSessionIdSanitized`, `TestApplyUpdateNewVersionSanitized`); 1 skipped (Unix-only SIGPIPE)
- [x] Sanity check — `shared.VERSION == monitor.VERSION == "1.10.2"`; `pulse.USER_AGENT` embeds `1.10.2`
- [ ] CI matrix green (ubuntu-3.8, ubuntu-3.10, ubuntu-3.11, ubuntu-3.12, windows-3.12, macos-3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
