### PR TITLE
docs(license): v1.10.4 — add SPDX-License-Identifier headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.10.4 — 2026-04-19
+
+License hygiene — follow-up to a license compliance audit that flagged missing SPDX headers as a low-severity gap.
+
+**Added `# SPDX-License-Identifier: MIT` header** (line 2, under the shebang) to all 6 Python source files:
+- `monitor.py`, `statusline.py`, `shared.py`, `pulse.py`, `update.py`, `tests.py`
+
+**Why:** The project was already MIT-licensed per `LICENSE` at the repo root, and compliant for general distribution. SPDX in-file headers are best practice per [REUSE](https://reuse.software/) and improve SBOM tooling (Software Bill of Materials), as well as OpenSSF Scorecard score. For single-license projects the headers are optional but recommended.
+
+**No functional change** — metadata-only patch.
+
 ## v1.10.3 — 2026-04-19
 
 Hotfix for a Windows startup regression introduced in v1.10.1 and a new diagnostic to prevent similar silent failures in the future.

--- a/monitor.py
+++ b/monitor.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Claude AIO Monitor — fullscreen TUI dashboard for Claude Code.
 
 Terminal dashboard (monitor.py + shared.py). Stdlib only.

--- a/pulse.py
+++ b/pulse.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Anthropic Pulse — backend stability monitor.
 
 Fetches status.claude.com summary.json + pings api.anthropic.com.

--- a/shared.py
+++ b/shared.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Shared helpers and rate calculation for monitor.py and statusline.py."""
 
 import os
@@ -31,7 +32,7 @@ DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.10.3"
+VERSION = "1.10.4"
 
 # Python files that ship with the app — used by syntax-check paths in update flow
 # (monitor.py:_apply_update_worker + update.py:apply_update). Must stay in sync.

--- a/statusline.py
+++ b/statusline.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Claude AIO Monitor — statusline for Claude Code.
 
 Stdlib-only status line script (uses shared.py for helpers).

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Unit tests for CC AIO MON — stdlib only, no pytest required.
 
 Run:

--- a/update.py
+++ b/update.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """update.py — self-update checker for CC AIO MON.
 
 Usage: python3 update.py           (read-only check)


### PR DESCRIPTION
## Summary

Follow-up to a license compliance audit. Adds `# SPDX-License-Identifier: MIT` at line 2 (under the shebang) of all 6 Python source files.

Project is already MIT-licensed per `LICENSE` at the repo root, so this is **metadata-only** — no functional change. The in-file headers are best practice per [REUSE](https://reuse.software/) and improve SBOM tooling + OpenSSF Scorecard score.

**Affected:** `monitor.py`, `statusline.py`, `shared.py`, `pulse.py`, `update.py`, `tests.py`

## Audit findings summary

| check | status |
|---|---|
| LICENSE (MIT, 2026) | ✓ |
| NOTICE (affiliation + trademark) | ✓ |
| Stdlib-only (77 imports verified) | ✓ |
| GH Actions SHA-pinned + reputable | ✓ |
| No vendored code | ✓ |
| Anthropic/Claude trademark disclaimer | ✓ |
| SPDX in-file headers | ← this PR |

## Test plan

- [x] `py -m py_compile ...` — clean
- [x] `py tests.py` — 490 pass, 1 skip
- [x] SPDX header present at line 2 of each source file (verified via `head -2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)