### PR TITLE
docs: workspace consistency pass — unify texts with reality, align GitHub workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -90,6 +90,12 @@ Audit postupy a audit logs live in `docs/audits/` (local-only, gitignored). Star
 3. `py -m py_compile monitor.py statusline.py shared.py update.py pulse.py`
 4. Stage explicitly by filename — **never** `git add .` or `git add -A`
 5. `git diff --cached` — final visual review
-6. Commit message format: `feat/fix/chore(scope): short description`
+6. Commit message format: `<type>(<scope>): <short description>`
+   - **Types:** `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `style`, `revert`
+   - **Scopes (established set):** `monitor`, `statusline`, `pulse`, `shared`, `update`, `tests`, `changelog`, `audit`, `security`, `license`, `docs`, `ci`
+   - **Release commits** use the same format — e.g. `feat(statusline): reset countdown + drop APR/CHR segments (v1.10.0)` or `fix(monitor): v1.10.3 — Windows UnboundLocalError on startup`. No special casing.
+   - **PR titles** match the squash-merge commit title exactly.
+   - **GitHub release titles** follow `vX.Y.Z — short human description` (em-dash `—`, not hyphen).
+   - **Git tags** are annotated, format `vX.Y.Z` (with `v` prefix).
 7. **Forbidden flags**: `--no-verify`, `--force`, `--no-gpg-sign`, `-c commit.gpgsign=false`
 8. Never amend already-pushed commits; create new commit instead

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -38,7 +38,7 @@ CC AIO MON reads session data from Claude Code via stdin and writes snapshots to
 
 - `GET https://status.claude.com/api/v2/summary.json` — public status page JSON (every 30 s)
 - `GET https://api.anthropic.com/v1/messages` — unauthenticated liveness probe; expects 401/405 (every 30 s)
-- Request body: none. Headers: `User-Agent: cc-aio-mon-pulse/<version>` only (version string reads from `shared.VERSION` — single source of truth since v1.10.2; currently `1.10.5`).
+- Request body: none. Headers: `User-Agent: cc-aio-mon-pulse/<version>` only — version string tracks `shared.VERSION` (single source of truth since v1.10.2).
 - Response size capped at 512 KB; socket timeouts 4–5 s.
 - Opt-out: set `CC_AIO_MON_NO_PULSE=1` to disable the background worker entirely.
 
@@ -64,3 +64,9 @@ Key protections:
 - Temp directory created with `0o700` permissions where supported
 - `update.py` guards: dirty tree, wrong branch, detached HEAD, divergence, downgrade, Python version mismatch
 - `pulse.py` uses `urllib.request.urlopen` with default CA verification (no `ssl._create_unverified_context`); errors are caught by specific type, never broadly suppressed in probe logic
+
+## See also
+
+- [README.md](../README.md) — feature overview and architecture
+- [NOTICE](../NOTICE) — legal notice and affiliation disclaimer
+- [CHANGELOG.md](../CHANGELOG.md) — release history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
   - `_rls_snapshot` / `_rls_write` helper correctness
 - Full suite: 477 tests, all passing (one skipped on Windows — the Unix-only SIGPIPE test).
 
-## v1.9.0 — 2026-04-16
+## v1.9.0 — 2026-04-17
 
 **New feature — Anthropic Pulse modal:**
 - New `pulse.py` module — real-time Anthropic backend stability monitor. Press `p` to open modal. Stdlib only, zero dependencies, zero token cost, cross-platform.
@@ -237,7 +237,6 @@
 - Untracked `PROMO.md` from git — was tracked despite `.gitignore` rule (added before ignore took effect).
 - `.claude/CLAUDE.md`: updated JSONL file size limits, shared.py description updated with new helpers.
 - `docs/setup-macos.md`: removed stale "not included in CI" note (macOS CI added in v1.8.1).
-- `docs/ROADMAP.md`: cost breakdown marked as Done (v1.8.0), multi-session keybinding changed from `m` to `v` (conflict with menu modal).
 - `README.md`: added menu modal and cost breakdown features, `m`/`c` keyboard shortcuts, updated security table (NTFS junction, lstat TOCTOU, CJK truncation), updated file size limits.
 
 **Tests:**

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,3 +11,5 @@ This project follows the [Contributor Covenant](https://www.contributor-covenant
 ## Enforcement
 
 Violations can be reported by opening a [private security advisory](../../security/advisories/new) (which supports confidential communication with the maintainer) or by opening a standard GitHub issue for non-sensitive matters. Reports will be reviewed and addressed promptly.
+
+See [.github/SECURITY.md](.github/SECURITY.md) for the same private reporting channel used for security vulnerabilities.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@
 ## What to keep in sync
 
 - **`shared.py` is the single source of truth** — all cross-file constants, helpers, ANSI palette, and regexes live there. Never duplicate a literal or a helper in `statusline.py` / `monitor.py` / `pulse.py` / `update.py`. The shared surface includes:
-  - **Constants:** `VERSION`, `PY_FILES`, `_SID_RE`, `_ANSI_RE`, `MAX_FILE_SIZE`, `TRANSCRIPT_MAX_BYTES`, `DATA_DIR_NAME`, `DATA_DIR`, `VERSION_RE`, `RESERVED_SIDS`.
+  - **Constants:** `VERSION`, `PY_FILES`, `_SID_RE`, `_ANSI_RE`, `MAX_FILE_SIZE`, `TRANSCRIPT_MAX_BYTES`, `DATA_DIR`, `VERSION_RE`, `RESERVED_SIDS`.
   - **ANSI palette:** `E`, `R`, `B`, `FAINT`, `C_RED`, `C_GRN`, `C_YEL`, `C_ORN`, `C_CYN`, `C_WHT`, `C_DIM`.
   - **Helpers:** `_num`, `_sanitize`, `safe_read`, `f_tok`, `f_cost`, `f_dur`, `f_cd`, `char_width`, `is_safe_dir`, `ensure_data_dir`, `strip_context_suffix`, `compact_context_suffix`, `extract_changelog_entry`, `run_git`, `calc_rates`.
   - If you add a helper or constant that is (or could be) used by more than one module, put it in `shared.py` from day one.
@@ -42,3 +42,11 @@ For anything non-trivial — new features, behavior changes, refactors beyond lo
 - One logical change per PR.
 - Include a description of what changed and why.
 - Reference any related issues.
+- Commit/PR title format: `<type>(<scope>): <short description>` — see `.claude/CLAUDE.md` Git Commit Policy.
+
+## See also
+
+- [README.md](README.md) — feature overview, metrics, keyboard shortcuts, architecture
+- [CHANGELOG.md](CHANGELOG.md) — release history
+- [.github/SECURITY.md](.github/SECURITY.md) — security model and vulnerability reporting
+- [NOTICE](NOTICE) — legal notice and affiliation disclaimer

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Other monitors scrape log files or estimate costs from token counts. CC AIO MON 
 - **Progress bars with configurable ranges** — BRN (default 0-10.0 $/min), CTR (default 0-10.0 %/min), CST (default 0-$1000) plus standard 0-100% bars for APR, CHR, CTX, 5HL, 7DL. Ceilings tunable via env vars (`CC_MON_BRN_MAX`, `CC_MON_CTR_MAX`, `CC_MON_CST_MAX`). Statusline 5HL/7DL segments also show a dimmed reset countdown (`→ 2h 15m`, `→ 6d 12h`) alongside the percentage.
 - **Smart warnings** — header alerts when context fills in < 30 min or burn rate exceeds threshold.
 - **Cross-session cost tracking** — TDY (today) and WEK (rolling 7-day) aggregate cost across all active Claude Code sessions.
-- **Token usage stats** — press `t` for a per-model token breakdown (In/Out/Calls), session count, active days, streaks, longest session, and most active day. Reads `~/.claude/projects/` transcripts. Filterable by All Time / Last 7 Days / Last 30 Days. Model bars and daily peak (TOP) count all token types: input + output + cache_read + cache_write.
+- **Token usage stats** — press `t` for a per-model token breakdown (In / Out / Calls, plus Cache Read and Cache Write rows when non-zero), session count, active days, streaks, longest session, and most active day. Reads `~/.claude/projects/` transcripts. Filterable by All Time / Last 7 Days / Last 30 Days. Model bars and daily peak (TOP) count all token types: input + output + cache_read + cache_write.
 - **Update manager** — press `u` to check for updates. Shows current vs remote version, new commits, changelog preview, and safety warnings. Press `a` to apply.
 <p align="center">
 <a href="screenshots/cc-aio-mon-stats.png"><img src="screenshots/cc-aio-mon-stats.png" alt="CC AIO MON — token stats modal with per-model breakdown using 3-char codes, includes cache tokens in bar"></a>
@@ -127,19 +127,20 @@ python3 monitor.py --refresh 1000  # custom refresh interval (ms, default 500)
 
 ### Keyboard Shortcuts
 
-| Key | Action |
-|-----|--------|
-| `q` | Quit |
-| `m` | Menu (navigation hub) |
-| `r` | Force refresh (resets stale timer) |
-| `s` | Switch session (picker) |
-| `t` | Token usage stats (per-model breakdown) |
-| `c` | Cost breakdown (token costs, cache savings, burn rate over time) |
-| `u` | Update manager (version check, changelog, apply) |
-| `p` | Anthropic Pulse (backend stability modal) |
-| `l` | Toggle legend overlay |
-| `1-9` | Select session (picker) |
-| `1/2/3` | Switch period in token usage stats (all/7d/30d) |
+| Key | Action | Context |
+|-----|--------|---------|
+| `q` | Quit | dashboard |
+| `m` | Menu (navigation hub) | dashboard |
+| `r` | Force refresh (resets stale timer) | dashboard |
+| `s` | Switch session (picker) | dashboard |
+| `t` | Token usage stats (per-model breakdown) | dashboard |
+| `c` | Cost breakdown (token costs, cache savings, burn rate over time) | dashboard |
+| `u` | Update manager (version check, changelog) | dashboard |
+| `a` | Apply update (fetches + runs `git pull --ff-only`) | inside update modal only |
+| `p` | Anthropic Pulse (backend stability modal) | dashboard |
+| `l` | Toggle legend overlay | dashboard |
+| `1`–`9` | Select session from picker | session picker only |
+| `1` / `2` / `3` | Switch period (all / 7d / 30d) | inside token-stats modal only |
 
 ### Session Picker
 
@@ -241,7 +242,7 @@ export CLAUDE_STATUS_CRIT=90
 ## Known Limitations
 
 - **Delayed refresh after context compaction** — when Claude Code compacts the context window, the dashboard continues showing the pre-compaction CTX value until Claude Code emits the next statusline event (typically the next assistant message). This is a Claude Code protocol limitation — `statusline.py` is only invoked on assistant messages, permission mode changes, or vim mode toggles. There is no external API to trigger a refresh on demand.
-- **Pricing drift** — model prices are hardcoded snapshots of Anthropic's published rates at release time. If Anthropic adjusts pricing, cost breakdown numbers drift until the next release. Pricing reflects Anthropic's published rates as of release date. Cost breakdown uses per-model cached-input multipliers (0.1×) and cache-write multipliers (1.25×). Current model family: Opus 4.7 / Sonnet 4.6 / Haiku 4.5.
+- **Pricing drift** — model prices are hardcoded snapshots of Anthropic's published rates at release time. If Anthropic adjusts pricing, cost breakdown numbers drift until the next release. Cost breakdown uses per-model cached-input multipliers (0.1×) and cache-write multipliers (1.25×). Current priced families: Opus (4.1 / 4.5 / 4.6 / 4.7), Sonnet (4.5 / 4.6), Haiku (3.5 / 4.5).
 
 ## Troubleshooting
 

--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -1,7 +1,5 @@
 # Setup — macOS
 
-> macOS is tested in CI (`macos-latest`, Python 3.12). Report issues if something breaks.
-
 > **Python command:** This guide uses `python3`. If your system only has `python` (no `python3`), replace every `python3` in the commands below with `python`. Run `check-requirements.sh` to see which command is detected on your machine.
 
 ## Requirements
@@ -120,3 +118,7 @@ No credentials, no user data, no request body is sent. If you are behind a restr
 ```bash
 CC_AIO_MON_NO_PULSE=1 python3 monitor.py
 ```
+
+## CI status
+
+CC AIO MON is CI-tested on macOS with **Python 3.12** only. Ubuntu covers 3.8, 3.10, 3.11, and 3.12. Python 3.8/3.10/3.11 on macOS are not CI-tested — the project targets Python 3.8+ but relies on the Ubuntu matrix to catch older-version regressions.

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -141,4 +141,4 @@ py monitor.py
 
 ## CI status
 
-CC AIO MON is CI-tested on Windows with **Python 3.12** (Ubuntu tests 3.8, 3.10, 3.11, 3.12). Python 3.8 on Windows is not CI-tested.
+CC AIO MON is CI-tested on Windows with **Python 3.12** only. Ubuntu covers 3.8, 3.10, 3.11, and 3.12. Python 3.8/3.10/3.11 on Windows are not CI-tested — the project targets Python 3.8+ but relies on the Ubuntu matrix to catch older-version regressions.


### PR DESCRIPTION
## Summary

Full consistency audit of the workspace identified 13 actionable items (0 critical, 4 high, 9 medium, 11 low). This PR fixes all of them in both local docs and GitHub release metadata.

### Local files

**Factual corrections:**
- \`CHANGELOG.md\`: v1.9.0 date off by one day (2026-04-16 → 2026-04-17, matches tag cut)
- \`CHANGELOG.md\`: removed orphan reference to non-existent \`docs/ROADMAP.md\` from v1.8.4 entry
- \`CONTRIBUTING.md\`: removed stale \`DATA_DIR_NAME\` from shared.py constants list (no runtime consumer since v1.9.0)
- \`.github/SECURITY.md\`: dropped hardcoded \"currently 1.10.5\" — now says \"tracks shared.VERSION\"

**README polish:**
- Keyboard shortcut table rebuilt with Context column — added \`a\` (apply-update, modal-only), disambiguated \`1-9\` (picker) vs \`1/2/3\` (stats period)
- Known Limitations updated with full priced model families: Opus 4.1/4.5/4.6/4.7, Sonnet 4.5/4.6, Haiku 3.5/4.5
- Token stats feature bullet now mentions Cache Read / Cache Write rows

**Cross-references added:**
- CONTRIBUTING.md → README + CHANGELOG + SECURITY + NOTICE
- CODE_OF_CONDUCT.md → SECURITY.md (same private advisory channel)
- SECURITY.md → README + NOTICE + CHANGELOG

**Conventions codified** in \`.claude/CLAUDE.md\` Git Commit Policy:
- Types: feat/fix/chore/docs/refactor/test/ci/style/revert
- Scopes: monitor/statusline/pulse/shared/update/tests/changelog/audit/security/license/docs/ci
- Release commits + PR titles + release titles + tag format all explicitly documented

**Setup guide structure aligned:**
- \`docs/setup-macos.md\`: CI status section moved to end (was top-of-file note), matching linux/windows structure
- \`docs/setup-windows.md\`: CI coverage gap description corrected (3.8 + 3.10 + 3.11 not tested on Windows, not just 3.8)

### GitHub releases (via \`gh release edit\`)

**12 release titles unified** to \`vX.Y.Z — <description>\` pattern:

| tag | before | after |
|---|---|---|
| v1.3 | \`v1.3\` | \`v1.3 — statusline redesign (text-only, compact)\` |
| v1.4 | \`v1.4\` | \`v1.4 — session switching + stale session picker\` |
| v1.5.2 | \`v1.5.2\` | \`v1.5.2 — shared calc_rates helper\` |
| v1.6.0 | \`v1.6.0\` | \`v1.6.0 — smart warnings + cross-session cost tracking\` |
| v1.6.3 | \`v1.6.3\` | \`v1.6.3 — setup guides bash -c fix\` |
| v1.6.4 | \`v1.6.4\` | \`v1.6.4 — rates.py renamed to shared.py\` |
| v1.8.0 | \`v1.8.0\` | \`v1.8.0 — release check + update manager\` |
| v1.8.1 | \`v1.8.1\` | \`v1.8.1 — dead session auto-purge\` |
| v1.8.2 | \`v1.8.2\` | \`v1.8.2 — BRN/CST ceilings raised for Opus 4.6 1M\` |
| v1.8.3 | \`v1.8.3\` | \`v1.8.3 — synthetic model filter in token stats\` |
| v1.10.1 | \`... (audit)\` | dropped internal \`(audit)\` reference |
| v1.10.2 | \`deep security scan follow-up\` | \`file-read hardening + shared.py single source of truth\` |
| v1.10.3 | \`... (UnboundLocalError regression from M-6)\` | dropped internal audit tag |
| v1.10.5 | \`... (post-audit)\` | dropped internal \`(post-audit)\` reference |

No code changes. \`VERSION\` stays at \`1.10.5\`.

## Test plan

- [x] \`py tests.py\` — 490 pass, 1 skip
- [x] \`gh release list\` shows consistent titles for all 22 releases
- [x] No broken cross-references in newly-linked docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)