### PR TITLE
docs(claude-md): add Known deferred items section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,6 +60,14 @@ Claude Code statusLine command MUST be wrapped in `bash -c '...'` — externé b
   - Audit logs, internal rule revisions, workflow conventions
   - If a commit touches **only** contributor/internal files: use a plain `docs(...)` or `chore(...)` commit, do **not** bump `VERSION`, do **not** create a tag, do **not** publish a release. The test is simple: would a user running `py monitor.py` notice anything different? If no → no CHANGELOG entry, no release.
 
+## Known deferred items
+
+Tracked debt explicitly deferred out of past audits. Re-surface in next audit session, or address individually when scope allows. Not release blockers.
+
+- **[refactor] `monitor.render_frame` split** (~200 LOC, 15+ branches over header/session/warnings/APR/CHR/CTX/5HL/7DL/BRN/CTR/CST/TDY/RLS/footer) — deferred from v1.10.5 audit to keep blast radius small.
+- **[refactor] `monitor.main()` event loop → state machine** (~300 LOC, 30+ elif chains mutating 7 modal flags; new modals currently need ~10 edits) — deferred from v1.10.5 audit.
+- **[bug] `update.get_local_version()` targets `monitor.py`** but `VERSION` moved to `shared.py` in v1.10.2 — `update.py --apply` raises "VERSION constant not found" on fresh clones. Low-impact (clear error, not silent corruption). Surfaced during v1.10.5 SEC-009 fix, outside original audit scope.
+
 ## Audit
 
 Audit postupy a audit logs live in `docs/audits/` (local-only, gitignored). Start with `AUDIT-PLAN.md`.


### PR DESCRIPTION
## Summary

Persistent tracker for debt explicitly deferred out of past audits.

`.claude/CLAUDE.md` is auto-injected into every Claude Code session, so listing deferred items there keeps them visible across sessions — no gitignored log file, no reliance on conversation context.

## Current entries

- **[refactor] `monitor.render_frame` split** — deferred from v1.10.5 audit
- **[refactor] `monitor.main()` event loop → state machine** — deferred from v1.10.5 audit
- **[bug] `update.get_local_version()` targets `monitor.py`** — VERSION moved to `shared.py` in v1.10.2; surfaced during v1.10.5 SEC-009 fix, outside original audit scope

## Scope

Internal-only change (contributor-facing rule file) — per the "CHANGELOG scope — app only" rule:

- No `CHANGELOG.md` entry
- No `VERSION` bump
- No tag, no release

## Test plan

- [x] `.claude/CLAUDE.md` is the project-rule SSOT consulted in every session
- [x] Placed before `## Audit` section for locality with audit workflow
- [x] Contributors see it on `.claude/CLAUDE.md` read