### PR TITLE
fix(audit): release check, null-field crashes, SSoT consolidation

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install Bandit
         run: pip install --require-hashes -r .github/workflows/requirements-bandit.txt
       - name: Run Bandit
-        run: bandit -r shared.py statusline.py monitor.py update.py pulse.py -f sarif -o bandit.sarif --severity-level medium || true
+        # File list sourced from shared.PY_FILES (single source of truth — see tests.yml compile step).
+        run: bandit -r $(python -c "from shared import PY_FILES; print(' '.join(PY_FILES))") -f sarif -o bandit.sarif --severity-level medium || true
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.10.6 — 2026-04-22
+
+**Statusline — reset countdown color:**
+- Removed ANSI faint (`\033[2m`) from the 5HL and 7DL reset countdown. The reset time (`→ 2h 58m`, `→ 1d 22h`) now renders in the same color as the percentage — yellow below the warn threshold, red at or above the critical threshold. Previously the countdown was intentionally dimmed to signal supplementary information; the effect rendered inconsistently across terminals and made the countdown harder to read.
+
+**Bug fixes:**
+- **Release check / self-update.** Since v1.10.2 the `VERSION` constant moved into `shared.py`, but the release-check worker in `monitor.py` and `update.py --apply` both still greped `monitor.py` for it. Result: the dashboard permanently showed `error` in the release indicator, and every `py update.py --apply` invocation raised `RuntimeError: VERSION constant not found in monitor.py` before doing anything. Both paths now read from `shared.py`.
+- **Dashboard crash on null payload fields.** A Claude Code status JSON with `"model": null`, `"context_window": null`, or `"cost": null` (rare but syntactically valid) raised `AttributeError` inside `render_frame` / `scan_transcript_stats`. `AttributeError` was not in the render loop's except allow-list, so the dashboard crashed via the excepthook and `monitor-crash.log`. Sixteen call sites switched from the `data.get("k", {})` default to the `data.get("k") or {}` pattern, which treats explicit `null` the same as a missing key.
+
 ## v1.10.5 — 2026-04-19
 
 **Security hardening:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@
 ## What to keep in sync
 
 - **`shared.py` is the single source of truth** — all cross-file constants, helpers, ANSI palette, and regexes live there. Never duplicate a literal or a helper in `statusline.py` / `monitor.py` / `pulse.py` / `update.py`. The shared surface includes:
-  - **Constants:** `VERSION`, `PY_FILES`, `_SID_RE`, `_ANSI_RE`, `MAX_FILE_SIZE`, `TRANSCRIPT_MAX_BYTES`, `DATA_DIR`, `VERSION_RE`, `RESERVED_SIDS`.
-  - **ANSI palette:** `E`, `R`, `B`, `FAINT`, `C_RED`, `C_GRN`, `C_YEL`, `C_ORN`, `C_CYN`, `C_WHT`, `C_DIM`.
-  - **Helpers:** `_num`, `_sanitize`, `safe_read`, `f_tok`, `f_cost`, `f_dur`, `f_cd`, `char_width`, `is_safe_dir`, `ensure_data_dir`, `strip_context_suffix`, `compact_context_suffix`, `extract_changelog_entry`, `run_git`, `calc_rates`.
+  - **Constants:** `VERSION`, `PY_FILES`, `_SID_RE`, `_ANSI_RE`, `MIN_EPOCH`, `MAX_FILE_SIZE`, `HISTORY_READ_MAX`, `HISTORY_AGGREGATE_MAX`, `TRANSCRIPT_MAX_BYTES`, `DATA_DIR`, `DATA_DIR_NAME`, `VERSION_RE`, `RESERVED_SIDS`, `WARN_PCT`, `CRIT_PCT`.
+  - **ANSI palette:** `E`, `R`, `B`, `C_RED`, `C_GRN`, `C_YEL`, `C_ORN`, `C_CYN`, `C_WHT`, `C_DIM`.
+  - **Helpers:** `_num`, `_sanitize`, `safe_read`, `f_tok`, `f_cost`, `f_dur`, `f_cd`, `char_width`, `is_safe_dir`, `ensure_data_dir`, `ensure_utf8_stdout`, `load_history`, `strip_context_suffix`, `compact_context_suffix`, `extract_changelog_entry`, `run_git`, `calc_rates`.
   - If you add a helper or constant that is (or could be) used by more than one module, put it in `shared.py` from day one.
 
 ## Pull requests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p align="center"><a href="screenshots/cc-aio-mon-dashboard.png"><img src="screenshots/cc-aio-mon-dashboard.png" alt="CC AIO MON — fullscreen TUI dashboard showing context window, API ratio, cache hit rate, rate limits, burn rate, cost, and cross-session totals with Nord color scheme"></a></p>
 
-<p align="center"><a href="screenshots/cc-aio-mon-statusline.png"><img src="screenshots/cc-aio-mon-statusline.png" alt="CC AIO MON — single-line ANSI status bar showing Model, CTX, 5HL, 7DL, CST, BRN segments with dimmed reset countdown"></a></p>
+<p align="center"><a href="screenshots/cc-aio-mon-statusline.png"><img src="screenshots/cc-aio-mon-statusline.png" alt="CC AIO MON — single-line ANSI status bar showing Model, CTX, 5HL, 7DL, CST, BRN segments with reset countdown"></a></p>
 
 ## Why CC AIO MON?
 
@@ -51,7 +51,7 @@ Other monitors scrape log files or estimate costs from token counts. CC AIO MON 
 - **Official stdin JSON** — reads Claude Code's `statusLine` JSON protocol via stdin. No log scraping, no file watching, no API polling. Real data, real-time.
 - **Two-tier architecture** — `statusline.py` (single-line status bar, triggered per Claude Code event) + `monitor.py` (fullscreen TUI, polls temp files independently).
 - **Temp file IPC** — atomic JSON snapshots + JSONL history in `$TMPDIR/claude-aio-monitor/`. No sockets, no databases, no shared memory. Works across terminal sessions.
-- **Progress bars with configurable ranges** — BRN (default 0-10.0 $/min), CTR (default 0-10.0 %/min), CST (default 0-$1000) plus standard 0-100% bars for APR, CHR, CTX, 5HL, 7DL. Ceilings tunable via env vars (`CC_MON_BRN_MAX`, `CC_MON_CTR_MAX`, `CC_MON_CST_MAX`). Statusline 5HL/7DL segments also show a dimmed reset countdown (`→ 2h 15m`, `→ 6d 12h`) alongside the percentage.
+- **Progress bars with configurable ranges** — BRN (default 0-10.0 $/min), CTR (default 0-10.0 %/min), CST (default 0-$1000) plus standard 0-100% bars for APR, CHR, CTX, 5HL, 7DL. Ceilings tunable via env vars (`CC_MON_BRN_MAX`, `CC_MON_CTR_MAX`, `CC_MON_CST_MAX`). Statusline 5HL/7DL segments also show a reset countdown (`→ 2h 15m`, `→ 6d 12h`) alongside the percentage.
 - **Smart warnings** — header alerts when context fills in < 30 min or burn rate exceeds threshold.
 - **Cross-session cost tracking** — TDY (today) and WEK (rolling 7-day) aggregate cost across all active Claude Code sessions.
 - **Token usage stats** — press `t` for a per-model token breakdown (In / Out / Calls, plus Cache Read and Cache Write rows when non-zero), session count, active days, streaks, longest session, and most active day. Reads `~/.claude/projects/` transcripts. Filterable by All Time / Last 7 Days / Last 30 Days. Model bars and daily peak (TOP) count all token types: input + output + cache_read + cache_write.
@@ -91,8 +91,8 @@ Press `r` to force a refresh (resets the stale timer if new data has arrived), o
 | **DUR** | Session duration (sub-stat of APR) | — | dashboard |
 | **CHR** | Cache read tokens / total cache | 0-100% | dashboard |
 | **CTX** | Context window usage | 0-100% | statusline + dashboard |
-| **5HL** | 5-hour rate limit usage + dimmed reset countdown (`→ 2h 15m`) | 0-100% | statusline + dashboard |
-| **7DL** | 7-day rate limit usage + dimmed reset countdown (`→ 6d 12h`) | 0-100% | statusline + dashboard |
+| **5HL** | 5-hour rate limit usage + reset countdown (`→ 2h 15m`) | 0-100% | statusline + dashboard |
+| **7DL** | 7-day rate limit usage + reset countdown (`→ 6d 12h`) | 0-100% | statusline + dashboard |
 | **BRN** | Cost burn rate | 0-10.0 $/min (env: `CC_MON_BRN_MAX`) | statusline + dashboard |
 | **CTR** | Context consumption rate | 0-10.0 %/min (env: `CC_MON_CTR_MAX`) | dashboard |
 | **CST** | Session cost | 0-$1000 (env: `CC_MON_CST_MAX`) | statusline + dashboard |
@@ -163,7 +163,7 @@ Both scripts import shared.py for shared BRN/CTR calculation.
 ```
 
 1. **Claude Code** emits JSON telemetry to `statusline.py` via stdin after each assistant message, permission mode change, or vim mode toggle (300ms debounce).
-2. **statusline.py** parses JSON, renders single-line ANSI status bar (model, context, rate limits with dimmed reset countdown, cost, burn rate), writes atomic snapshot (`.json`) + appends to history (`.jsonl`).
+2. **statusline.py** parses JSON, renders single-line ANSI status bar (model, context, rate limits with reset countdown, cost, burn rate), writes atomic snapshot (`.json`) + appends to history (`.jsonl`).
 3. **monitor.py** polls temp directory (data files refresh every 500 ms; UI tick 50 ms for keyboard responsiveness), reads snapshots + history, renders fullscreen TUI with progress bars and computed metrics.
 4. **shared.py** provides `calc_rates()` — computes BRN ($/min) and CTR (%/min) from JSONL history timestamps.
 

--- a/monitor.py
+++ b/monitor.py
@@ -15,7 +15,6 @@ Usage:
 import argparse
 import atexit
 import bisect
-import codecs
 import json
 import os
 import pathlib
@@ -33,9 +32,10 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 
 from shared import (calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_dur, f_cd,
-                    char_width, is_safe_dir, ensure_data_dir, run_git,
+                    char_width, is_safe_dir, ensure_data_dir, ensure_utf8_stdout, run_git,
                     load_history as _shared_load_history,
-                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, TRANSCRIPT_MAX_BYTES,
+                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, HISTORY_AGGREGATE_MAX, TRANSCRIPT_MAX_BYTES,
+                    WARN_PCT, CRIT_PCT,
                     DATA_DIR, VERSION_RE, VERSION, PY_FILES,
                     RESERVED_SIDS, strip_context_suffix, compact_context_suffix,
                     extract_changelog_entry,
@@ -175,8 +175,8 @@ def scan_transcript_stats(period="all", ttl=30.0):
                     if not msg or "usage" not in msg:
                         continue
 
-                    model = msg.get("model", "unknown")
-                    if model.startswith("<") or not model:
+                    model = msg.get("model") or "unknown"
+                    if model.startswith("<"):
                         continue  # skip synthetic/internal entries
                     u = msg["usage"]
                     inp = int(_num(u.get("input_tokens", 0)))
@@ -351,8 +351,7 @@ def _env_float(name, default):
 
 
 WARN_BRN = _env_float("CLAUDE_WARN_BRN", 3.0)
-WARN_PCT = _env_float("CLAUDE_STATUS_WARN", 50.0)
-CRIT_PCT = _env_float("CLAUDE_STATUS_CRIT", 80.0)
+# WARN_PCT/CRIT_PCT imported from shared.py (SSoT; previously parsed per module)
 
 # Reset-countdown color flip — 50% of window remaining (NOT the warn threshold)
 RESET_HALFWAY_PCT = 50.0
@@ -465,7 +464,7 @@ def collect_warnings(data, cpm, xpm):
     warnings = []
     # CTF — context filling fast
     if xpm and xpm > 0:
-        ctx_pct = _num(data.get("context_window", {}).get("used_percentage"))
+        ctx_pct = _num((data.get("context_window") or {}).get("used_percentage"))
         if ctx_pct < 100:
             eta_mins = (100 - ctx_pct) / xpm
             if eta_mins < 30:
@@ -527,7 +526,7 @@ def _rls_check_worker():
         if r.returncode != 0:
             _rls_write("error")
             return
-        r = run_git(["show", "origin/main:monitor.py"], cwd=_REPO_ROOT, timeout=15)
+        r = run_git(["show", "origin/main:shared.py"], cwd=_REPO_ROOT, timeout=15)
         if r.returncode != 0:
             _rls_write("error")
             return
@@ -597,11 +596,11 @@ def calc_cross_session_costs():
         # Bounded read — stat check + safe_read cap closes TOCTOU window
         try:
             st = jl.stat()
-            if st.st_size > MAX_FILE_SIZE * 10:
+            if st.st_size > HISTORY_AGGREGATE_MAX:
                 continue
         except OSError:
             continue
-        raw_bytes = safe_read(jl, MAX_FILE_SIZE * 10)
+        raw_bytes = safe_read(jl, HISTORY_AGGREGATE_MAX)
         if raw_bytes is None:
             continue
         try:
@@ -622,7 +621,7 @@ def calc_cross_session_costs():
         final_today = 0.0
         first_today = None
         for e in entries:
-            cost = _num(e.get("cost", {}).get("total_cost_usd"))
+            cost = _num((e.get("cost") or {}).get("total_cost_usd"))
             if _num(e.get("t"), 0) < today_start:
                 baseline_today = cost
             else:
@@ -637,7 +636,7 @@ def calc_cross_session_costs():
         final_week = 0.0
         first_week = None
         for e in entries:
-            cost = _num(e.get("cost", {}).get("total_cost_usd"))
+            cost = _num((e.get("cost") or {}).get("total_cost_usd"))
             if _num(e.get("t"), 0) < week_start:
                 baseline_week = cost
             else:
@@ -711,7 +710,7 @@ def list_sessions():
                 continue
             d = json.loads(raw.decode("utf-8"))
             # Skip snapshots without usable model info (test artifacts / incomplete writes)
-            display_name = _sanitize(d.get("model", {}).get("display_name", "")).strip()
+            display_name = _sanitize((d.get("model") or {}).get("display_name", "")).strip()
             if not display_name:
                 # Cleanup: dead artifact older than 1 hour
                 if (now - mt) > 3600:
@@ -840,17 +839,18 @@ def render_frame(data, hist, cols, rows, show_legend=False, show_menu=False, sho
     buf = []
 
     # -- Extract data (sanitize to prevent terminal escape injection) --
-    m = data.get("model", {})
+    # `or {}` pattern guards against explicit JSON `null` values (not just missing keys).
+    m = data.get("model") or {}
     model_str = _sanitize(m.get("display_name", "?")).replace("(1M context)", "(1M CTX)")
     sname = _sanitize(data.get("session_name", ""))
 
-    cw = data.get("context_window", {})
+    cw = data.get("context_window") or {}
     ctx_pct = round(_num(cw.get("used_percentage")), 1)
     ctx_total = _num(cw.get("context_window_size"), 0)
     usage = cw.get("current_usage") or {}
 
     rl = data.get("rate_limits")
-    cost_d = data.get("cost", {})
+    cost_d = data.get("cost") or {}
     usd = _num(cost_d.get("total_cost_usd"))
     dur = _num(cost_d.get("total_duration_ms"))
     api_dur = _num(cost_d.get("total_api_duration_ms"))
@@ -1137,7 +1137,7 @@ _SESSION_COST_CACHE = OrderedDict()  # LRU: {session_id: (ts, breakdown_dict)}
 _SESSION_COST_CACHE_MAX = 64  # cap — prevents unbounded growth across rotating session IDs
 _SESSION_COST_TTL = 5.0   # refresh every 5s
 
-CLAUDE_PROJECTS_DIR = (pathlib.Path.home() / ".claude" / "projects").resolve()
+CLAUDE_PROJECTS_DIR = _CLAUDE_DIR.resolve()
 
 
 def _safe_transcript_path(tp):
@@ -1259,7 +1259,7 @@ def _cost_thirds(hist):
     costs = []
     for entry in hist:
         t = _num(entry.get("t", 0))
-        c = _num(entry.get("cost", {}).get("total_cost_usd", 0))
+        c = _num((entry.get("cost") or {}).get("total_cost_usd", 0))
         if t > 0:
             costs.append((t, c))
     if len(costs) < 2:
@@ -1293,12 +1293,12 @@ def render_cost_breakdown(data, hist, cols, rows):
     buf.append(f"{BG_BAR}{C_WHT}{B}COST BREAKDOWN{R}{BG_BAR}{' ' * cb_pad}{R}")
     buf.append(sep(SW))
 
-    cost_d = data.get("cost", {})
+    cost_d = data.get("cost") or {}
     usd = _num(cost_d.get("total_cost_usd"))
     dur = _num(cost_d.get("total_duration_ms"))
-    cw = data.get("context_window", {})
+    cw = data.get("context_window") or {}
     usage = cw.get("current_usage") or {}
-    model_id = data.get("model", {}).get("id", "")
+    model_id = (data.get("model") or {}).get("id", "")
     pricing = _get_pricing(model_id)
 
     # Token counts
@@ -1309,7 +1309,7 @@ def render_cost_breakdown(data, hist, cols, rows):
     total_in = _num(cw.get("total_input_tokens", 0))
     total_out = _num(cw.get("total_output_tokens", 0))
 
-    model_name = _sanitize(data.get("model", {}).get("display_name", "?"))
+    model_name = _sanitize((data.get("model") or {}).get("display_name", "?"))
     # Strip verbose context suffix: "Opus 4.6 (1M context)" → "Opus 4.6 1M"
     model_short = compact_context_suffix(model_name)
     buf.append(f"{C_ORN}{B}CST{R} {C_ORN}{B}{f_cost(usd)}{R} {C_DIM}{f_dur(dur)} - {model_short}{R}")
@@ -2108,16 +2108,7 @@ def main():
 
     args.refresh = max(100, min(60000, args.refresh))
 
-    try:
-        is_utf8 = sys.stdout.encoding and codecs.lookup(sys.stdout.encoding).name == "utf-8"
-    except LookupError:
-        is_utf8 = False
-    if not is_utf8:
-        sys.stdout.flush()
-        sys.stdout = open(
-            sys.stdout.fileno(), mode="w", encoding="utf-8",
-            errors="replace", closefd=False,
-        )
+    ensure_utf8_stdout()
 
     if args.list:
         for s in list_sessions():

--- a/pulse.py
+++ b/pulse.py
@@ -454,6 +454,8 @@ def cleanup_log_startup():
             rec = json.loads(line)
         except ValueError:
             continue  # drop malformed
+        if not isinstance(rec, dict):
+            continue  # drop bare JSON values (e.g. '123\n', '"x"\n')
         ts = rec.get("ts", 0)
         if isinstance(ts, (int, float)) and ts >= cutoff:
             kept.append(line + "\n")

--- a/shared.py
+++ b/shared.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Shared helpers and rate calculation for monitor.py and statusline.py."""
 
+import codecs
 import json
 import os
 import pathlib
@@ -28,13 +29,51 @@ _SID_RE = re.compile(
 )
 _ANSI_RE = re.compile(r"\033(?:\[[0-9;?]*[a-zA-Z~]|\][^\x07]*\x07)")
 MAX_FILE_SIZE = 1_048_576  # 1 MB
+HISTORY_READ_MAX = MAX_FILE_SIZE * 2   # 2 MB — per-session JSONL read cap (headroom over 1 MB trim target)
+HISTORY_AGGREGATE_MAX = MAX_FILE_SIZE * 10  # 10 MB — cross-session cost aggregation cap
 TRANSCRIPT_MAX_BYTES = 50 * 1024 * 1024  # 50 MiB — cap on per-transcript reads
 DATA_DIR_NAME = "claude-aio-monitor"
 DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.10.5"
+VERSION = "1.10.6"
+
+
+def ensure_utf8_stdout():
+    """Force sys.stdout to UTF-8 when the current encoding can't render app glyphs.
+
+    Windows default console encodings (cp1250/cp1252) can't handle em-dashes,
+    box-drawing, or CJK. Each entry point (statusline/monitor/update) calls
+    this at the top of main() before any write.
+    """
+    try:
+        is_utf8 = sys.stdout.encoding and codecs.lookup(sys.stdout.encoding).name == "utf-8"
+    except LookupError:
+        is_utf8 = False
+    if is_utf8:
+        return
+    sys.stdout.flush()
+    sys.stdout = open(
+        sys.stdout.fileno(), mode="w", encoding="utf-8",
+        errors="replace", closefd=False,
+    )
+
+
+def _env_pct(name, default):
+    """Parse a percentage env var as float, fall back on empty/invalid input."""
+    try:
+        v = os.environ.get(name, "")
+        if v:
+            return float(v)
+    except (ValueError, TypeError):
+        pass
+    return default
+
+
+# Percentage thresholds shared by statusline + monitor (SSoT, previously parsed twice).
+WARN_PCT = _env_pct("CLAUDE_STATUS_WARN", 50.0)
+CRIT_PCT = _env_pct("CLAUDE_STATUS_CRIT", 80.0)
 
 # Python files that ship with the app — used by syntax-check paths in update flow
 # (monitor.py:_apply_update_worker + update.py:apply_update). Must stay in sync.
@@ -44,7 +83,6 @@ PY_FILES = ("monitor.py", "statusline.py", "shared.py", "pulse.py", "update.py")
 E = "\033["
 R = E + "0m"
 B = E + "1m"
-FAINT = E + "2m"
 C_RED = E + "38;2;191;97;106m"
 C_GRN = E + "38;2;163;190;140m"
 C_YEL = E + "38;2;235;203;139m"
@@ -87,11 +125,12 @@ def load_history(sid, n=120, data_dir=None):
     DATA_DIR continues to work).
     """
     dd = data_dir if data_dir is not None else DATA_DIR
-    if not _SID_RE.match(str(sid)):
+    sid_s = str(sid)
+    if not _SID_RE.match(sid_s) or sid_s in RESERVED_SIDS:
         return []
     if not is_safe_dir(dd):
         return []
-    raw = safe_read(dd / f"{sid}.jsonl", MAX_FILE_SIZE * 2)
+    raw = safe_read(dd / f"{sid_s}.jsonl", HISTORY_READ_MAX)
     if raw is None:
         return []
     try:
@@ -110,8 +149,11 @@ def load_history(sid, n=120, data_dir=None):
 def safe_read(path, max_bytes):
     """Bounded read — returns bytes or None. Never reads more than max_bytes + 1.
 
-    Closes TOCTOU gap: caller doesn't have to stat first, and even if they do,
-    an attacker growing the file between stat and read cannot exceed max_bytes.
+    Closes the size TOCTOU gap: caller doesn't have to stat first, and even if
+    they do, an attacker growing the file between stat and read cannot exceed
+    max_bytes. Does NOT validate containment — symlinks and junctions are
+    followed as Python's default open() does. Callers must pre-validate paths
+    (e.g. via is_safe_dir / _safe_transcript_path) when that matters.
     Returns None on OSError, on >max_bytes overflow, or on missing file.
     """
     try:

--- a/statusline.py
+++ b/statusline.py
@@ -12,7 +12,6 @@ Config env vars:
     CLAUDE_STATUS_CRIT  — red threshold % (default 80)
 """
 
-import codecs
 import json
 import os
 import pathlib
@@ -24,22 +23,10 @@ import tempfile
 import time
 
 from shared import (calc_rates as _calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_cd,
-                    is_safe_dir, ensure_data_dir, load_history as _shared_load_history,
-                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, DATA_DIR, RESERVED_SIDS,
-                    strip_context_suffix,
-                    R, B, FAINT, C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
-
-# ---------------------------------------------------------------------------
-# Config
-# ---------------------------------------------------------------------------
-try:
-    WARN = int(os.environ.get("CLAUDE_STATUS_WARN", "50"))
-except (ValueError, TypeError):
-    WARN = 50
-try:
-    CRIT = int(os.environ.get("CLAUDE_STATUS_CRIT", "80"))
-except (ValueError, TypeError):
-    CRIT = 80
+                    ensure_data_dir, ensure_utf8_stdout, load_history as _shared_load_history,
+                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, HISTORY_READ_MAX, DATA_DIR, RESERVED_SIDS,
+                    strip_context_suffix, WARN_PCT, CRIT_PCT,
+                    R, B, C_RED, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
 
 
 
@@ -118,9 +105,9 @@ def _get_terminal_width(fallback: int = 80) -> int:
 
 def cpc_base(pct, base):
     """Threshold color — uses metric's own base color below WARN (matches monitor mkbar behavior)."""
-    if pct >= CRIT:
+    if pct >= CRIT_PCT:
         return C_RED
-    if pct >= WARN:
+    if pct >= WARN_PCT:
         return C_YEL
     return base
 
@@ -136,14 +123,14 @@ _SEP_VLEN = 3  # " │ "
 # Segment builders — each returns (text, visible_length) or None
 # ---------------------------------------------------------------------------
 def seg_model(data):
-    name = _sanitize(data.get("model", {}).get("display_name", ""))
+    name = _sanitize((data.get("model") or {}).get("display_name", ""))
     name = strip_context_suffix(name).replace(" (200k)", "")
     text = f"{B}{C_WHT}{name}{R}"
     return text, len(_ANSI_RE.sub("", text))
 
 
 def seg_ctx(data):
-    cw = data.get("context_window", {})
+    cw = data.get("context_window") or {}
     pct = round(_num(cw.get("used_percentage")))
     total = _num(cw.get("context_window_size"), 0)
     used = int(total * pct / 100) if total else 0
@@ -166,7 +153,7 @@ def seg_5hl(data):
     if resets > 0 and resets < now:
         pct = 0
     c = cpc_base(pct, C_YEL)
-    reset_str = f" {FAINT}{c}\u2192 {f_cd(resets)}{R}" if resets > now else ""
+    reset_str = f" {c}\u2192 {f_cd(resets)}{R}" if resets > now else ""
     text = f"{c}{B}5HL{R} {c}{pct}%{R}{reset_str}"
     return text, len(_ANSI_RE.sub("", text))
 
@@ -184,13 +171,13 @@ def seg_7dl(data):
     if resets > 0 and resets < now:
         pct = 0
     c = cpc_base(pct, C_YEL)
-    reset_str = f" {FAINT}{c}\u2192 {f_cd(resets)}{R}" if resets > now else ""
+    reset_str = f" {c}\u2192 {f_cd(resets)}{R}" if resets > now else ""
     text = f"{c}{B}7DL{R} {c}{pct}%{R}{reset_str}"
     return text, len(_ANSI_RE.sub("", text))
 
 
 def seg_cost(data):
-    usd = _num(data.get("cost", {}).get("total_cost_usd"))
+    usd = _num((data.get("cost") or {}).get("total_cost_usd"))
     if usd <= 0:
         return None
     text = f"{C_ORN}CST{R} {C_ORN}{B}{f_cost(usd)}{R}"
@@ -243,17 +230,10 @@ def main():
             signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         except (AttributeError, ValueError):
             pass
-    # Force UTF-8 on Windows (cp1250/cp1252 can't handle unicode box-drawing)
-    try:
-        is_utf8 = sys.stdout.encoding and codecs.lookup(sys.stdout.encoding).name == "utf-8"
-    except LookupError:
-        is_utf8 = False
-    if not is_utf8:
-        sys.stdout.flush()
-        sys.stdout = open(sys.stdout.fileno(), mode="w", encoding="utf-8", errors="replace", closefd=False)
+    ensure_utf8_stdout()
 
     try:
-        raw = sys.stdin.read(1_048_576)  # 1 MB limit
+        raw = sys.stdin.read(MAX_FILE_SIZE)
         if not raw.strip():
             return
         data = json.loads(raw)
@@ -352,8 +332,7 @@ def write_shared_state(data: dict):
 
 def _trim_history(path: pathlib.Path):
     fd = None
-    # Bounded read — JSONL trim cap is MAX_FILE_SIZE * 2
-    raw = safe_read(path, MAX_FILE_SIZE * 2)
+    raw = safe_read(path, HISTORY_READ_MAX)
     if raw is None:
         return
     try:

--- a/tests.py
+++ b/tests.py
@@ -2195,7 +2195,7 @@ class TestUpdate(unittest.TestCase):
             import update
             old_root = update.REPO_ROOT
             update.REPO_ROOT = Path(td)
-            (Path(td) / "monitor.py").write_text('VERSION = "1.2.3"\n', encoding="utf-8")
+            (Path(td) / "shared.py").write_text('VERSION = "1.2.3"\n', encoding="utf-8")
             try:
                 result = update.get_local_version()
                 self.assertEqual(result, "1.2.3")
@@ -2208,7 +2208,7 @@ class TestUpdate(unittest.TestCase):
             import update
             old_root = update.REPO_ROOT
             update.REPO_ROOT = Path(td)
-            (Path(td) / "monitor.py").write_text("VERSION = '2.0.0'\n", encoding="utf-8")
+            (Path(td) / "shared.py").write_text("VERSION = '2.0.0'\n", encoding="utf-8")
             try:
                 result = update.get_local_version()
                 self.assertEqual(result, "2.0.0")
@@ -2233,7 +2233,7 @@ class TestUpdate(unittest.TestCase):
             import update
             old_root = update.REPO_ROOT
             update.REPO_ROOT = Path(td)
-            (Path(td) / "monitor.py").write_text("# no version here\n", encoding="utf-8")
+            (Path(td) / "shared.py").write_text("# no version here\n", encoding="utf-8")
             try:
                 with self.assertRaises(RuntimeError):
                     update.get_local_version()
@@ -5038,12 +5038,12 @@ class TestAuditRegressionV1105(unittest.TestCase):
 
     def test_sec009_update_get_local_version_uses_safe_read(self):
         """SEC-009: get_local_version enforces a size cap via safe_read,
-        returning a clear error on oversized monitor.py rather than OOM."""
+        returning a clear error on oversized shared.py rather than OOM."""
         import update
-        # Monkey-patch REPO_ROOT to a tempdir with an oversized monitor.py
+        # Monkey-patch REPO_ROOT to a tempdir with an oversized shared.py
         tmpdir = tempfile.mkdtemp()
         try:
-            mpath = pathlib.Path(tmpdir) / "monitor.py"
+            mpath = pathlib.Path(tmpdir) / "shared.py"
             # Write slightly over MAX_FILE_SIZE (1 MB) — safe_read rejects it
             mpath.write_bytes(b'VERSION = "9.9.9"\n' + b"x" * (shared.MAX_FILE_SIZE + 10))
             orig = update.REPO_ROOT

--- a/update.py
+++ b/update.py
@@ -11,7 +11,6 @@ macOS/Linux: python3). Stdlib only.
 """
 
 import argparse
-import codecs
 import datetime
 import os
 import re
@@ -20,7 +19,7 @@ import sys
 from pathlib import Path
 from shared import (
     VERSION_RE, MAX_FILE_SIZE, _sanitize, run_git as _shared_run_git,
-    extract_changelog_entry, PY_FILES, safe_read,
+    ensure_utf8_stdout, extract_changelog_entry, PY_FILES, safe_read,
 )
 
 if sys.platform == "win32":
@@ -39,15 +38,7 @@ def _enable_vt_on_windows():
 
 def _init_terminal():
     """Set up UTF-8 stdout and VT processing. Called from main() only."""
-    # Force UTF-8 on Windows (cp1250/cp1252 can't handle em-dash, box chars)
-    try:
-        is_utf8 = sys.stdout.encoding and codecs.lookup(sys.stdout.encoding).name == "utf-8"
-    except LookupError:
-        is_utf8 = False
-    if not is_utf8:
-        sys.stdout.flush()
-        sys.stdout = open(sys.stdout.fileno(), mode="w", encoding="utf-8",
-                          errors="replace", closefd=False)
+    ensure_utf8_stdout()
     _enable_vt_on_windows()
 
 
@@ -120,26 +111,26 @@ def fetch_remote():
 
 
 def get_local_version():
-    monitor = REPO_ROOT / "monitor.py"
-    if not monitor.exists():
-        raise RuntimeError("monitor.py not found")
-    raw = safe_read(monitor, MAX_FILE_SIZE)
+    source = REPO_ROOT / "shared.py"
+    if not source.exists():
+        raise RuntimeError("shared.py not found")
+    raw = safe_read(source, MAX_FILE_SIZE)
     if raw is None:
-        raise RuntimeError(f"monitor.py: unreadable or too large (>{MAX_FILE_SIZE} bytes)")
+        raise RuntimeError(f"shared.py: unreadable or too large (>{MAX_FILE_SIZE} bytes)")
     content = raw.decode("utf-8", errors="replace")
     m = VERSION_RE.search(content)
     if not m:
-        raise RuntimeError("VERSION constant not found in monitor.py")
+        raise RuntimeError("VERSION constant not found in shared.py")
     return m.group(1)
 
 
 def get_remote_version():
-    r = run_git(["show", "origin/main:monitor.py"])
+    r = run_git(["show", "origin/main:shared.py"])
     if r.returncode != 0:
-        raise RuntimeError("Failed to read remote monitor.py")
+        raise RuntimeError("Failed to read remote shared.py")
     m = VERSION_RE.search(r.stdout)
     if not m:
-        raise RuntimeError("VERSION constant not found in remote monitor.py")
+        raise RuntimeError("VERSION constant not found in remote shared.py")
     return m.group(1)
 
 
@@ -196,7 +187,7 @@ def apply_update():
 
     try:
         new_ver = get_local_version()
-        # VERSION_RE matches [^"']+ — on-disk monitor.py could carry ANSI;
+        # VERSION_RE matches [^"']+ — on-disk shared.py could carry ANSI;
         # sanitize before echoing to terminal.
         ok(f"New VERSION: {_sanitize(new_ver)}")
     except Exception as e:


### PR DESCRIPTION
## Summary

- **BLOCKER — Release check / self-update restored.** Since v1.10.2 the \`VERSION\` constant moved into \`shared.py\`, but \`monitor.py\`'s release-check worker and \`update.py\`'s \`get_local_version\`/\`get_remote_version\` both still greped \`monitor.py\`. The dashboard showed permanent \`error\` in the release indicator and \`py update.py --apply\` raised \`RuntimeError\` before doing anything. Both call sites now target \`shared.py\`.
- **BLOCKER — Dashboard crash on null payload fields.** A status JSON with \`\"model\": null\`, \`\"context_window\": null\`, or \`\"cost\": null\` crashed \`render_frame\` / \`scan_transcript_stats\` with \`AttributeError\` — which was not in the render-loop except allow-list. 16 sites switched from \`.get(\"k\", {})\` to \`.get(\"k\") or {}\`.
- **SSoT + workspace consolidation.** \`WARN_PCT\`/\`CRIT_PCT\` parsed once in \`shared.py\` (was duplicated between statusline int and monitor float). \`HISTORY_READ_MAX\` / \`HISTORY_AGGREGATE_MAX\` replace \`MAX_FILE_SIZE * 2\` / \`* 10\` ad-hoc multipliers. \`ensure_utf8_stdout()\` helper replaces three copies of the UTF-8 reopen block. \`bandit.yml\` now sources the file list from \`shared.PY_FILES\` (was hardcoded). \`CONTRIBUTING.md\` shared-surface lists updated; dead \`FAINT\` constant removed.

Also folds the pre-existing v1.10.6 WIP (reset-countdown color flattening + \`VERSION\` bump).

## Test plan

- [ ] CI tests pass on ubuntu 3.8 / 3.10 / 3.11 / 3.12 + windows 3.12 + macos 3.12
- [ ] Bandit scan clean (new PY_FILES expansion exercises all five modules)
- [ ] Scorecard workflow unaffected
- [ ] Live Windows: \`py monitor.py\` renders, dashboard does not crash, release-check indicator shows \`OK\` (not \`error\`)
- [ ] Live Linux/macOS: \`py monitor.py\` renders (SIGPIPE path, /dev/tty width probe still work after \`ensure_utf8_stdout\` refactor)
- [ ] \`py update.py\` prints current local version (previously raised \`RuntimeError: VERSION constant not found in monitor.py\`)
- [ ] Null-field regression: pipe \`{\"model\":null,\"context_window\":null,\"cost\":null,\"session_id\":\"test\"}\` to \`statusline.py\` — no crash
- [ ] Null-field regression: feed same payload into a test session file and open \`py monitor.py\` — dashboard renders without excepthook