### PR TITLE
docs(changelog): correct v1.11.0 entry — drop stale-tag claim, fix test count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 **New features — surface fresh data from Claude Code:**
 - **AI-generated session titles in the picker and dashboard header.** Claude Code writes auto-generated titles into transcript JSONL (`{"type":"ai-title","aiTitle":"..."}`). The session picker (`s`) and dashboard session label now show that title instead of the bare UUID when no `session_name` is set. CLI `--list` also benefits. Fallback chain: `session_name` → `ai_title` → `id[:N]`.
-- **Lifetime activity panel in the token-stats modal (`t`).** A new section reads `~/.claude/stats-cache.json` (CC's pre-aggregated lifetime stats) and renders: total sessions / messages / tool-call count, first session date, longest session duration, a 24-hour heatmap of activity (UTC), and the last 5 daily activity rows. The panel auto-collapses on small terminals (DAILY first, then the whole block) so it never clips the rest of the modal. Stale cache (older than 24 h) is tagged.
+- **Lifetime activity panel in the token-stats modal (`t`).** A new section reads `~/.claude/stats-cache.json` (CC's pre-aggregated lifetime stats) and renders: total sessions / messages / tool-call count, first session date, longest session duration, a 24-hour heatmap of activity (UTC), and the last 5 daily activity rows. The panel auto-collapses on small terminals (DAILY first, then the whole block) so it never clips the rest of the modal. The cached date is shown in the panel header.
 - **Server-side tool calls and 1h/5m cache split in the cost-breakdown modal (`c`).** The session aggregator now counts `web_search_requests`, `web_fetch_requests` (`server_tool_use`) and `ephemeral_1h_input_tokens` / `ephemeral_5m_input_tokens` (`cache_creation`). The cost modal shows new `WSR/WFR` and `TIE/T5M` rows in `SESSION TOTALS` only when the values are non-zero — old transcripts and zero-tool sessions render unchanged.
 
-**Tests:** 540 passing (+39).
+**Tests:** 539 passing (+38).
 
 ## v1.10.6 — 2026-04-22
 


### PR DESCRIPTION
## Summary

Two small corrections to the v1.11.0 CHANGELOG entry to match the shipped behaviour:

- **"Stale cache (older than 24 h) is tagged."** removed — the `(stale)` tag was dropped during pre-release polish; the cached date in the panel header conveys the same information.
- **"540 passing (+39)" → "539 passing (+38)"** — `test_stale_tag_when_cache_old` was removed alongside the stale tag, leaving 539 tests in `tests.py`.

No code or behaviour changes; CHANGELOG-only.

## Test plan

- [x] `py tests.py` → still 539 passing
- [ ] CI: required status checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)