### PR TITLE
v1.12.2 — P2/P3 audit cleanup, +20 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,15 @@ secrets/
 # SSH keys (defense-in-depth)
 id_rsa*
 id_ed25519*
+id_ecdsa*
+.ssh/
+known_hosts
+
+# Service accounts & credential stores (defense-in-depth)
+service-account*.json
+.netrc
+*.kdbx
+.aws/credentials
 
 # Backup / merge artifacts
 *.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## v1.12.2 — 2026-05-25
+
+Audit-cleanup release: outstanding P2 + P3 findings from the 24.05.2026
+five-dimension audit (REPORT.md backed up to `D:\backups\audit-24.05.2026-cc-aio-mon.zip`).
+No new features, no user-visible behavior change beyond two niche edges
+(crash log always-rotates, `pulse.indicator_label` is now a public name).
+
+**Reliability:**
+- **Crash log always rotates (P3 ARCH).** `rotate_crash_log` gains an
+  `always=False` parameter; `monitor.py:_install_crash_logger` passes
+  `always=True` so the previous traceback is preserved (as `.log.1`) even
+  when both crashes are well under the 1 MB size threshold. Prevents
+  silent loss of diagnostics when two crashes happen in quick succession.
+  +2 regression tests.
+
+**API tidy-up:**
+- **`pulse.indicator_label` is public (P3 ARCH).** Renamed from
+  `_indicator_label` because `monitor.render_pulse_modal` was already
+  reaching across module boundaries to call it. The mapping
+  (Statuspage indicator → human label) is a stable contract; the leading
+  underscore was misleading.
+
+**Code hygiene — internal:**
+- **Named time constants (P3 STYLE-003).** `shared.SECONDS_1H` /
+  `SECONDS_5H` / `SECONDS_1D` / `SECONDS_7D` replace the bare `3600`
+  / `18000` / `86400` / `604800` magic numbers in `monitor.py` (rate-limit
+  windows, dead-snapshot cleanup, ago-time formatter, cross-session week
+  cutoff) and `pulse.py` (`LOG_AGE_CUTOFF`). No behavior change.
+- **`HISTORY_RATE_SAMPLES` constant (P3 ARCH).** The magic `n=120` default
+  in `load_history` (≈ a 2-hour rolling window at one statusline event per
+  minute) is now a named constant in `shared.py`, propagated to the
+  `monitor.load_history` and `statusline._load_history_for_rates` wrappers.
+- **`_MODELS` defined in one place (P3 ARCH).** The placeholder
+  `_MODELS = {}` at the top of the cost-breakdown section plus the
+  `_MODELS.update({...})` call 900 LOC later in the token-stats section
+  are gone — the model registry is now a single dict literal next to
+  `_DEFAULT_PRICING` where it is first used.
+- **`flush(cols)` is now a required arg (P3 ARCH).** The `cols=None`
+  default that fell back to `shutil.get_terminal_size()` was unreachable
+  in production (every call site already had the value); removed the dead
+  branch.
+- **`isinstance(..., bool)` exclusion (P3 STYLE-005).** `pulse.py`
+  `_classify_incident` now explicitly excludes `bool` from its
+  `isinstance(impact_override, (str, int, float))` check — `bool` is an
+  `int` subclass, so `True` / `False` would otherwise leak through into
+  the model-family string match.
+- **`# noqa: BLE001` on `_rls_maybe_check` swallow (P3 STYLE-004).** The
+  best-effort `except Exception` on `Thread().start()` failure is
+  intentional; the comment makes that explicit.
+
+**Security — defense in depth:**
+- **`.gitignore` extended (P3 SEC).** Added `id_ecdsa*`, `.ssh/`,
+  `known_hosts`, `service-account*.json`, `.netrc`, `*.kdbx`, and
+  `.aws/credentials` to the credentials block.
+
+**Tests:**
+- **`extract_changelog_entry` direct unit tests (P3 TEST).** Six new
+  cases in `test_shared.py`: middle entry extraction, last-entry-at-EOF
+  anchor, missing version, empty input, `max_lines` truncation, and
+  regex-metachar escaping in the version string.
+- **`strip_context_suffix` / `compact_context_suffix` direct tests
+  (P3 TEST).** Eight cases in `test_shared.py` covering 1M / 200k
+  suffixes, no-suffix passthrough, and empty input for both helpers.
+- **`update.check_python_version` test (P3 TEST).** Three cases pinning
+  the exit-on-too-old behavior, the at-minimum no-op, and the
+  newer-version no-op — using a `namedtuple` stand-in for the
+  non-constructible `sys.version_info` structseq.
+- **`safe_read` `PermissionError` path (P3 TEST).** Pins that any
+  `OSError`, not just `FileNotFoundError`, returns `None` cleanly.
+- **`TestApplyUpdateAction.test_syntax_check_uses_safe_read` no longer
+  patches `pathlib.Path.exists` globally (P2 T-P2-4).** Uses a real
+  tmpdir + real stub file, so unrelated `Path.exists` calls in the
+  test body are unaffected.
+- **`TestCalcRates.test_shared_module_identity` renamed (P2 T-P2-7)**
+  to `test_monitor_and_statusline_alias_shared_calc_rates` with a
+  docstring stating the SSoT invariant it guards.
+
+**Tests:** 605 passing (+20).
+
 ## v1.12.1 — 2026-05-25
 
 **Bug fixes — Windows / non-UTF-8 locale rendering:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
    `unittest discover tests/`, so the `py tests.py` invocation continues to work
    unchanged.
 
-   **Baseline: 585 tests passing (3 skipped on platforms missing optional artifacts).**
+   **Baseline: 605 tests passing (3 skipped on platforms missing optional artifacts).**
    Contributions must not reduce the passing count without explanation. If you add
    tests, put them in the file that matches the module under test — helpers go in
    `test_shared.py`, TUI logic in `test_monitor.py`, and so on.

--- a/docs/FILE-IPC-CONTRACT.md
+++ b/docs/FILE-IPC-CONTRACT.md
@@ -255,12 +255,13 @@ After successful snapshot write:
 
 ### Reading (shared.py + monitor.py)
 
-**Function**: `load_history(sid, n=120, data_dir=None)` (`shared.py:122-153`)
+**Function**: `load_history(sid, n=HISTORY_RATE_SAMPLES, data_dir=None)` (`shared.py:122-153`)
 
-Single source of truth for both statusline and monitor.
+Single source of truth for both statusline and monitor. `HISTORY_RATE_SAMPLES`
+defaults to 120 — at ~1 statusline event/min this is a ~2-hour rolling window.
 
 ```python
-def load_history(sid, n=120, data_dir=None):
+def load_history(sid, n=HISTORY_RATE_SAMPLES, data_dir=None):
     """Read last n JSONL history entries for session `sid`.
     
     Returns list of parsed dicts (best-effort — malformed lines skipped).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -55,13 +55,13 @@ Work through these in order before creating any tag.
   python3 tests.py     # macOS / Linux
   ```
   `tests.py` is a thin wrapper that runs `unittest discover tests/`
-  (`tests.py:main()`). Current baseline: **585 passing** (v1.12.1). The new
+  (`tests.py:main()`). Current baseline: **605 passing** (v1.12.2). The new
   release's count must be >= this number unless tests were intentionally
   removed (document the removal in CHANGELOG).
 
 - [ ] **CHANGELOG entry drafted** (see Section 3 for exact format).
   Write the entry for the new version at the top of `CHANGELOG.md`, above the
-  current `## v1.12.1` block. Do not push yet.
+  current `## v1.12.2` block. Do not push yet.
 
 - [ ] **VERSION constant bumped in `shared.py` only.**
   The constant lives at `shared.py:46`:

--- a/monitor.py
+++ b/monitor.py
@@ -34,8 +34,11 @@ from shared import (calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_dur
                     char_width, is_safe_dir, ensure_data_dir, ensure_utf8_stdout, run_git,
                     load_history as _shared_load_history,
                     _SID_RE, _ANSI_RE, MAX_FILE_SIZE, HISTORY_AGGREGATE_MAX, TRANSCRIPT_MAX_BYTES,
+                    SECONDS_1H, SECONDS_5H, SECONDS_1D, SECONDS_7D,
+                    HISTORY_RATE_SAMPLES,
                     WARN_PCT, CRIT_PCT,
-                    DATA_DIR, VERSION_RE, VERSION, PY_FILES,
+                    DATA_DIR, VERSION_RE, VERSION,
+                    PY_FILES,  # noqa: F401 — pinned by TestPyFilesSingleSourceOfTruth (SSoT regression guard)
                     RESERVED_SIDS, strip_context_suffix, compact_context_suffix,
                     extract_changelog_entry,
                     check_syntax_after_pull, parse_ahead_behind,
@@ -206,9 +209,9 @@ def scan_transcript_stats(period="all", ttl=30.0):
     cutoff = 0
     wall = time.time()
     if period == "7d":
-        cutoff = wall - 7 * 86400
+        cutoff = wall - SECONDS_7D
     elif period == "30d":
-        cutoff = wall - 30 * 86400
+        cutoff = wall - 30 * SECONDS_1D
 
     models = {}
     active_days = set()
@@ -606,7 +609,7 @@ _cost_cache = {"t": 0.0, "today": 0.0, "week": 0.0}
 # RLS — background release check
 # ---------------------------------------------------------------------------
 _REPO_ROOT = pathlib.Path(__file__).parent.resolve()
-_RLS_TTL = 3600  # check once per hour
+_RLS_TTL = SECONDS_1H  # check once per hour
 _RLS_BLINK_INTERVAL = 0.5
 _rls_cache = {"t": -_RLS_TTL, "status": None, "remote_ver": None}
 _rls_lock = threading.Lock()       # worker-spawn coordination (one check at a time)
@@ -684,7 +687,7 @@ def _rls_maybe_check():
     try:
         t = threading.Thread(target=_rls_check_worker, daemon=True)
         t.start()
-    except Exception:
+    except Exception:  # noqa: BLE001 — RLS check is best-effort; must not crash main loop
         _rls_lock.release()
 
 
@@ -728,7 +731,7 @@ def calc_cross_session_costs():
     if not DATA_DIR.exists() or not is_safe_dir(DATA_DIR):
         return 0.0, 0.0
     today_start = datetime.combine(datetime.today().date(), datetime.min.time()).timestamp()
-    week_start = today_start - 6 * 86400
+    week_start = today_start - 6 * SECONDS_1D
     today_total = 0.0
     week_total = 0.0
     for jl in DATA_DIR.glob("*.jsonl"):
@@ -853,7 +856,7 @@ def list_sessions():
             display_name = _sanitize((d.get("model") or {}).get("display_name", "")).strip()
             if not display_name:
                 # Cleanup: dead artifact older than 1 hour
-                if (now - mt) > 3600:
+                if (now - mt) > SECONDS_1H:
                     try:
                         f.unlink()
                         f.with_suffix(".jsonl").unlink(missing_ok=True)
@@ -890,7 +893,7 @@ def load_state(sid):
 
 # Thin wrapper — shared.load_history is the single source of truth (v1.10.5+).
 # Passes monitor.DATA_DIR explicitly so tests that monkey-patch it still hit the fixture.
-def load_history(sid, n=120):
+def load_history(sid, n=HISTORY_RATE_SAMPLES):
     return _shared_load_history(sid, n, data_dir=DATA_DIR)
 
 
@@ -1107,8 +1110,8 @@ def render_frame(data, hist, cols, rows, show_legend=False, show_menu=False, sho
 
         fh = rl.get("five_hour")
         sd = rl.get("seven_day")
-        _render_rate_limit(fh, "5HL", 18000)   # 5 h window
-        _render_rate_limit(sd, "7DL", 604800)  # 7 d window
+        _render_rate_limit(fh, "5HL", SECONDS_5H)
+        _render_rate_limit(sd, "7DL", SECONDS_7D)
         if not fh and not sd:
             buf.append(f"{C_DIM}Rate limits: no data{R}")
     else:
@@ -1271,10 +1274,34 @@ def render_legend(cols, rows):
 # Prices per 1M tokens (USD). Sources: official Anthropic pricing page.
 # cache_write = 5-minute TTL price. 1h cache write adds ~60% — documented separately.
 _DEFAULT_PRICING = {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75}  # Sonnet-tier fallback
-# Single source of truth for model metadata (display name, short code, pricing).
-# Adding a new model = one entry here, not three. _MODELS is populated after
-# the helpers are defined below (line ~1800) to keep model-related data colocated.
-_MODELS = {}
+
+# Single source of truth for model metadata — keyed by Anthropic model ID.
+# Each entry: {"name": "...", "code": ("XX", "V.v"), "pricing": {...} | None}
+# Pricing is per-1M-token USD (input / output / cache_read / cache_write).
+# Adding a new model = one entry here, not three. Used by _get_pricing (below),
+# _model_code / _model_label (token-stats modal section, ~line 2200).
+_MODELS = {
+    "claude-opus-4-7": {"name": "Opus 4.7", "code": ("OP", "4.7"),
+                        "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
+    "claude-opus-4-6": {"name": "Opus 4.6", "code": ("OP", "4.6"),
+                        "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
+    "claude-opus-4-5": {"name": "Opus 4.5", "code": ("OP", "4.5"),
+                        "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
+    "claude-opus-4-1": {"name": "Opus 4.1", "code": ("OP", "4.1"),
+                        "pricing": {"input": 15.0, "output": 75.0, "cache_read": 1.50, "cache_write": 18.75}},
+    "claude-sonnet-4-6": {"name": "Sonnet 4.6", "code": ("SO", "4.6"),
+                          "pricing": {"input": 3.0,  "output": 15.0, "cache_read": 0.30, "cache_write": 3.75}},
+    "claude-sonnet-4-5": {"name": "Sonnet 4.5", "code": ("SO", "4.5"),
+                          "pricing": {"input": 3.0,  "output": 15.0, "cache_read": 0.30, "cache_write": 3.75}},
+    "claude-haiku-4-5-20251001": {"name": "Haiku 4.5", "code": ("HA", "4.5"),
+                                   "pricing": {"input": 1.0,  "output": 5.0,  "cache_read": 0.10, "cache_write": 1.25}},
+    "claude-haiku-3-5": {"name": "Haiku 3.5", "code": ("HA", "3.5"),
+                         "pricing": {"input": 0.8,  "output": 4.0,  "cache_read": 0.08, "cache_write": 1.00}},
+    # Short-ID fallbacks (some transcript entries use abbreviated IDs). No pricing.
+    "haiku":  {"name": "Haiku",  "code": ("HA", ""), "pricing": None},
+    "sonnet": {"name": "Sonnet", "code": ("SO", ""), "pricing": None},
+    "opus":   {"name": "Opus",   "code": ("OP", ""), "pricing": None},
+}
 
 
 def _get_pricing(model_id):
@@ -1706,9 +1733,9 @@ def _pulse_age(snap):
     age_s = max(0, int(time.time() - wall_t))
     if age_s < 60:
         return f"{age_s}s ago"
-    if age_s < 3600:
+    if age_s < SECONDS_1H:
         return f"{age_s // 60}m ago"
-    return f"{age_s // 3600}h ago"
+    return f"{age_s // SECONDS_1H}h ago"
 
 
 def render_pulse_modal(cols, rows):
@@ -1744,7 +1771,7 @@ def render_pulse_modal(cols, rows):
     # Details
     indicator = snap.get("indicator")
     if indicator:
-        ind_label = pulse._indicator_label(indicator)
+        ind_label = pulse.indicator_label(indicator)
         if indicator == "none":
             ind_color = C_GRN
         elif indicator in ("minor", "maintenance"):
@@ -2078,10 +2105,10 @@ def render_update_modal(cols, rows):
         age_s = max(0, int(time.monotonic() - rls.get("t", 0)))
         if age_s < 60:
             age_str = f"{age_s}s ago"
-        elif age_s < 3600:
+        elif age_s < SECONDS_1H:
             age_str = f"{age_s // 60}m ago"
         else:
-            age_str = f"{age_s // 3600}h ago"
+            age_str = f"{age_s // SECONDS_1H}h ago"
         buf.append(f"{C_DIM}Checked {age_str}{R}")
 
     buf.append(f"{C_CYN}github.com/iM3SK/cc-aio-mon{R}")
@@ -2165,32 +2192,6 @@ def render_update_modal(cols, rows):
 # ---------------------------------------------------------------------------
 _PERIOD_LABELS = {"all": "All Time", "7d": "Last 7 Days", "30d": "Last 30 Days"}
 _PERIOD_CYCLE = ["all", "7d", "30d"]
-
-# Single source of truth for model metadata — keyed by Anthropic model ID.
-# Each entry: {"name": "...", "code": ("XX", "V.v"), "pricing": {...} | None}
-# Pricing is per-1M-token USD (input / output / cache_read / cache_write).
-_MODELS.update({
-    "claude-opus-4-7": {"name": "Opus 4.7", "code": ("OP", "4.7"),
-                        "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
-    "claude-opus-4-6": {"name": "Opus 4.6", "code": ("OP", "4.6"),
-                        "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
-    "claude-opus-4-5": {"name": "Opus 4.5", "code": ("OP", "4.5"),
-                        "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
-    "claude-opus-4-1": {"name": "Opus 4.1", "code": ("OP", "4.1"),
-                        "pricing": {"input": 15.0, "output": 75.0, "cache_read": 1.50, "cache_write": 18.75}},
-    "claude-sonnet-4-6": {"name": "Sonnet 4.6", "code": ("SO", "4.6"),
-                          "pricing": {"input": 3.0,  "output": 15.0, "cache_read": 0.30, "cache_write": 3.75}},
-    "claude-sonnet-4-5": {"name": "Sonnet 4.5", "code": ("SO", "4.5"),
-                          "pricing": {"input": 3.0,  "output": 15.0, "cache_read": 0.30, "cache_write": 3.75}},
-    "claude-haiku-4-5-20251001": {"name": "Haiku 4.5", "code": ("HA", "4.5"),
-                                   "pricing": {"input": 1.0,  "output": 5.0,  "cache_read": 0.10, "cache_write": 1.25}},
-    "claude-haiku-3-5": {"name": "Haiku 3.5", "code": ("HA", "3.5"),
-                         "pricing": {"input": 0.8,  "output": 4.0,  "cache_read": 0.08, "cache_write": 1.00}},
-    # Short-ID fallbacks (some transcript entries use abbreviated IDs). No pricing.
-    "haiku":  {"name": "Haiku",  "code": ("HA", ""), "pricing": None},
-    "sonnet": {"name": "Sonnet", "code": ("SO", ""), "pricing": None},
-    "opus":   {"name": "Opus",   "code": ("OP", ""), "pricing": None},
-})
 
 _MODEL_ID_RE = re.compile(r"^claude-(opus|sonnet|haiku)-(\d+)-(\d+)")
 # Match human-readable display names (e.g. "Opus 4.6 (1M context)") — used by render_picker
@@ -2526,9 +2527,7 @@ def render_picker(sessions, cols, rows):
 # ---------------------------------------------------------------------------
 # Screen flush
 # ---------------------------------------------------------------------------
-def flush(buf, cols=None):
-    if cols is None:
-        cols = shutil.get_terminal_size((80, 24)).columns
+def flush(buf, cols):
     out = [SYNC_ON, HOME]
     for i, line in enumerate(buf):
         out.append(truncate(line, cols))
@@ -2558,9 +2557,10 @@ def _install_crash_logger():
         try:
             if ensure_data_dir(DATA_DIR):
                 log_path = DATA_DIR / "monitor-crash.log"
-                # Rotate before each crash write so the log never grows unbounded
-                # across many crash cycles (keeps last large crash + current one).
-                rotate_crash_log(log_path)
+                # Always rotate so two crashes in quick succession don't
+                # silently overwrite each other (open("w") below truncates).
+                # Previous crash → .log.1, current crash → .log.
+                rotate_crash_log(log_path, always=True)
                 with open(log_path, "w", encoding="utf-8") as f:
                     f.write(f"monitor v{VERSION} crashed at {time.ctime()}\n")
                     f.write(f"platform: {sys.platform}, python: {sys.version}\n")

--- a/pulse.py
+++ b/pulse.py
@@ -40,7 +40,7 @@ import urllib.error
 import urllib.request
 from collections import deque
 
-from shared import DATA_DIR, MAX_FILE_SIZE, ensure_data_dir, safe_read, VERSION
+from shared import DATA_DIR, MAX_FILE_SIZE, SECONDS_1D, ensure_data_dir, safe_read, VERSION
 
 # ---------------------------------------------------------------------------
 # Config
@@ -67,7 +67,7 @@ _OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 # Persistence + cleanup
 LOG_PATH = DATA_DIR / "pulse.jsonl"
 LOG_MAX_BYTES = MAX_FILE_SIZE    # 1 MB — single source of truth via shared
-LOG_AGE_CUTOFF = 24 * 3600       # startup: drop entries older than 24h
+LOG_AGE_CUTOFF = SECONDS_1D      # startup: drop entries older than 24h
 LOG_TRIM_TARGET = 500            # runtime rotation: keep last N lines
 LOG_STARTUP_CAP = 2000           # startup: hard cap on record count
 ROTATE_CHECK_EVERY = 100         # runtime: check size every N appends
@@ -146,7 +146,10 @@ def _latency_score(latency_ms):
     return 10
 
 
-def _indicator_label(indicator):
+def indicator_label(indicator):
+    """Map Statuspage indicator value to human-readable label. Public API
+    so monitor.render_pulse_modal can format it without reaching into a
+    private symbol."""
     m = {
         "none": "operational",
         "maintenance": "maintenance",
@@ -257,7 +260,7 @@ def compute_score(raw):
     # Reason: pick dominant factor
     reasons = []
     if indicator and indicator != "none":
-        reasons.append(f"status: {_indicator_label(indicator)}")
+        reasons.append(f"status: {indicator_label(indicator)}")
     if incidents:
         reasons.append(f"{len(incidents)} active incident(s)")
     if latency_ms is None:
@@ -364,7 +367,11 @@ def _tag_models_from_incident(inc):
     if isinstance(updates, list) and updates and isinstance(updates[0], dict):
         body = (updates[0].get("body") or "").lower()
     impact_override = inc.get("impact_override")
-    impact_override_s = str(impact_override).lower() if isinstance(impact_override, (str, int, float)) else ""
+    impact_override_s = (
+        str(impact_override).lower()
+        if isinstance(impact_override, (str, int, float)) and not isinstance(impact_override, bool)
+        else ""
+    )
     text = f"{title} {impact_override_s} {body}"
     for fam in ("opus", "sonnet", "haiku"):
         if re.search(rf"\b{fam}\b", text):

--- a/shared.py
+++ b/shared.py
@@ -38,12 +38,20 @@ MAX_FILE_SIZE = 1_048_576  # 1 MB
 HISTORY_READ_MAX = MAX_FILE_SIZE * 2   # 2 MB — per-session JSONL read cap (headroom over 1 MB trim target)
 HISTORY_AGGREGATE_MAX = MAX_FILE_SIZE * 10  # 10 MB — cross-session cost aggregation cap
 TRANSCRIPT_MAX_BYTES = 50 * 1024 * 1024  # 50 MiB — cap on per-transcript reads
+
+# Named time constants — eliminate magic-number duplication across monitor/pulse/statusline.
+# All values are seconds (wall-clock or monotonic context depends on call site).
+SECONDS_1H = 3600
+SECONDS_5H = 5 * SECONDS_1H        # 18000 — Claude rate-limit "5-hour" window
+SECONDS_1D = 24 * SECONDS_1H       # 86400
+SECONDS_7D = 7 * SECONDS_1D        # 604800 — Claude rate-limit "7-day" window
+
 DATA_DIR_NAME = "claude-aio-monitor"
 DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.12.1"
+VERSION = "1.12.2"
 
 # File-IPC contract version. Statusline writes this field on every snapshot
 # and history entry; bumped when the JSON shape changes incompatibly. Monitor
@@ -51,6 +59,11 @@ VERSION = "1.12.1"
 # silently ignored — making the tag future-proof but advisory today. A future
 # monitor read site (e.g. read_session_snapshot) can gate on this value.
 SCHEMA_VERSION = 1
+
+# Default sample window for load_history(). At ~1 statusline event/min this
+# yields a ~2-hour rolling window — enough for BRN/CTR rate smoothing without
+# rereading the entire per-session JSONL.
+HISTORY_RATE_SAMPLES = 120
 
 
 def ensure_utf8_stdout():
@@ -125,7 +138,7 @@ def _num(v, default=0):
         return default
 
 
-def load_history(sid, n=120, data_dir=None):
+def load_history(sid, n=HISTORY_RATE_SAMPLES, data_dir=None):
     """Read last n JSONL history entries for session `sid`.
 
     Single source of truth for both monitor.py (BRN/CTR dashboard rates) and
@@ -395,15 +408,23 @@ def parse_ahead_behind(rev_list_output):
     return int(parts[0]), int(parts[1])
 
 
-def rotate_crash_log(path, max_bytes=MAX_FILE_SIZE):
-    """Rotate ``path`` to ``path.1`` when its size exceeds ``max_bytes``.
+def rotate_crash_log(path, max_bytes=MAX_FILE_SIZE, always=False):
+    """Rotate ``path`` to ``path.1`` when size exceeds ``max_bytes``, or
+    unconditionally when ``always=True``.
+
+    ``always=True`` preserves the prior crash even when the current log is
+    well under ``max_bytes`` — otherwise two crashes in quick succession (both
+    small) would silently overwrite the first via ``open("w")``. Callers that
+    only care about disk-growth bounds keep the default.
 
     Best-effort: any OSError is silently swallowed so the calling crash-log
     writer never crashes the process it is trying to record. Drops any
-    pre-existing ``path.1`` before rotating. Idempotent on small files.
+    pre-existing ``path.1`` before rotating. Idempotent on missing files.
     """
     try:
-        if not path.exists() or path.stat().st_size <= max_bytes:
+        if not path.exists():
+            return
+        if not always and path.stat().st_size <= max_bytes:
             return
         backup = path.with_suffix(path.suffix + ".1")
         if backup.exists():

--- a/statusline.py
+++ b/statusline.py
@@ -23,8 +23,8 @@ import time
 
 from shared import (calc_rates as _calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_cd,
                     ensure_data_dir, ensure_utf8_stdout, load_history as _shared_load_history,
-                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, HISTORY_READ_MAX, DATA_DIR, RESERVED_SIDS,
-                    SCHEMA_VERSION,
+                    _SID_RE, _ANSI_RE, MAX_FILE_SIZE, HISTORY_READ_MAX, HISTORY_RATE_SAMPLES,
+                    DATA_DIR, RESERVED_SIDS, SCHEMA_VERSION,
                     strip_context_suffix, WARN_PCT, CRIT_PCT,
                     R, B, C_RED, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
 
@@ -272,7 +272,7 @@ HISTORY_TRIM_TO = 1000
 # MAX_FILE_SIZE, DATA_DIR imported from shared.py
 
 
-def _load_history_for_rates(sid, n=120):
+def _load_history_for_rates(sid, n=HISTORY_RATE_SAMPLES):
     """Read last n history entries for BRN/CTR rate computation. Call BEFORE write_shared_state.
 
     Thin wrapper around shared.load_history — both modules share the same reader

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -287,7 +287,9 @@ class TestCalcRates(unittest.TestCase):
         self.assertIsNotNone(brn)
         self.assertIsNone(ctr)
 
-    def test_shared_module_identity(self):
+    def test_monitor_and_statusline_alias_shared_calc_rates(self):
+        """SSoT regression guard: both monitor and statusline must re-export
+        shared.calc_rates by identity (not a wrapped/forked copy)."""
         from monitor import calc_rates as m_cr
         self.assertIs(m_cr, shared.calc_rates)
         self.assertIs(sl_calc_rates, shared.calc_rates)

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -322,6 +322,13 @@ class TestSafeRead(unittest.TestCase):
         finally:
             os.unlink(p)
 
+    def test_returns_none_on_permission_error(self):
+        """An unreadable existing file (any OSError, not just missing)
+        must return None — caller treats the read as a failed datapoint
+        rather than propagating an exception into the render path."""
+        with patch("builtins.open", side_effect=PermissionError("denied")):
+            self.assertIsNone(shared.safe_read("any/path", 100))
+
 
 class TestVersionSingleSourceOfTruth(unittest.TestCase):
     """I-1: VERSION lives in shared.py; monitor + pulse import from there."""
@@ -488,6 +495,30 @@ class TestRotateCrashLog(unittest.TestCase):
         # Must not raise
         rotate_crash_log(nonexistent, max_bytes=100)
 
+    def test_always_rotates_small_file(self):
+        """always=True must rotate even when file is well under max_bytes.
+        Guards against two-crashes-in-quick-succession losing first traceback."""
+        from shared import rotate_crash_log, MAX_FILE_SIZE
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".log") as f:
+            f.write(b"first crash traceback")
+            p = pathlib.Path(f.name)
+        backup = p.with_suffix(p.suffix + ".1")
+        try:
+            rotate_crash_log(p, max_bytes=MAX_FILE_SIZE, always=True)
+            self.assertFalse(p.exists(), "original must be gone after always-rotate")
+            self.assertTrue(backup.exists(), ".1 backup must exist")
+            self.assertEqual(backup.read_bytes(), b"first crash traceback")
+        finally:
+            p.unlink(missing_ok=True)
+            backup.unlink(missing_ok=True)
+
+    def test_always_no_op_when_path_missing(self):
+        """always=True must not raise when the source path does not exist."""
+        from shared import rotate_crash_log
+        nonexistent = pathlib.Path(tempfile.gettempdir()) / "cc_aio_rotate_always_nonexist_xyz.log"
+        rotate_crash_log(nonexistent, always=True)
+        self.assertFalse(nonexistent.exists())
+
 
 class TestPyFilesSingleSourceOfTruth(unittest.TestCase):
     """I-2: PY_FILES in shared.py is the single source of truth for syntax-check list."""
@@ -646,6 +677,82 @@ class TestAcquireSingletonLockCrossPlatform(unittest.TestCase):
                 fh.close()
             except OSError:
                 pass
+
+
+class TestExtractChangelogEntry(unittest.TestCase):
+    """Direct unit tests for shared.extract_changelog_entry. Previously
+    covered only indirectly via test_update (TestUpdate / TestGetRemoteChangelogPreview)."""
+
+    def test_extracts_middle_entry(self):
+        text = (
+            "## v1.2.0\n"
+            "feat: middle\n"
+            "\n"
+            "## v1.1.0\n"
+            "fix: old\n"
+        )
+        out = shared.extract_changelog_entry(text, "1.2.0")
+        self.assertIn("## v1.2.0", out)
+        self.assertIn("feat: middle", out)
+        self.assertNotIn("v1.1.0", out)
+
+    def test_extracts_last_entry_at_eof(self):
+        """Final entry has no following '## v' — pattern must anchor on \\Z."""
+        text = "## v0.9.0\nfeat: trailing\n"
+        out = shared.extract_changelog_entry(text, "0.9.0")
+        self.assertIn("feat: trailing", out)
+        self.assertTrue(out.startswith("## v0.9.0"))
+
+    def test_missing_version_returns_empty_string(self):
+        text = "## v1.0.0\nfeat: only\n"
+        self.assertEqual(shared.extract_changelog_entry(text, "9.9.9"), "")
+
+    def test_empty_input_returns_empty_string(self):
+        self.assertEqual(shared.extract_changelog_entry("", "1.0.0"), "")
+
+    def test_max_lines_truncates(self):
+        body = "\n".join(f"line {i}" for i in range(20))
+        text = f"## v2.0.0\n{body}\n"
+        out = shared.extract_changelog_entry(text, "2.0.0", max_lines=5)
+        self.assertEqual(len(out.splitlines()), 5)
+
+    def test_version_with_regex_metachars_is_escaped(self):
+        """Versions like 1.0.0+build.1 contain regex metachars — re.escape
+        must prevent them from acting as the regex's '.' wildcard."""
+        text = "## v1.0.0+build.1\nfeat: a\n\n## v1X0X0PbuildX1\nfeat: b\n"
+        out = shared.extract_changelog_entry(text, "1.0.0+build.1")
+        self.assertIn("feat: a", out)
+        self.assertNotIn("feat: b", out)
+
+
+class TestContextSuffixHelpers(unittest.TestCase):
+    """Direct unit tests for shared.strip_context_suffix and
+    compact_context_suffix. Previously only covered implicitly through
+    statusline rendering tests."""
+
+    def test_strip_removes_1m_context(self):
+        self.assertEqual(shared.strip_context_suffix("Opus 4.7 (1M context)"), "Opus 4.7")
+
+    def test_strip_removes_200k_context(self):
+        self.assertEqual(shared.strip_context_suffix("Sonnet 4.6 (200k context)"), "Sonnet 4.6")
+
+    def test_strip_no_suffix_unchanged(self):
+        self.assertEqual(shared.strip_context_suffix("Opus 4.7"), "Opus 4.7")
+
+    def test_strip_empty_input(self):
+        self.assertEqual(shared.strip_context_suffix(""), "")
+
+    def test_compact_inlines_1m(self):
+        self.assertEqual(shared.compact_context_suffix("Opus 4.7 (1M context)"), "Opus 4.7 1M")
+
+    def test_compact_inlines_200k(self):
+        self.assertEqual(shared.compact_context_suffix("Sonnet 4.6 (200k context)"), "Sonnet 4.6 200k")
+
+    def test_compact_no_suffix_unchanged(self):
+        self.assertEqual(shared.compact_context_suffix("Opus 4.7"), "Opus 4.7")
+
+    def test_compact_empty_input(self):
+        self.assertEqual(shared.compact_context_suffix(""), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -442,15 +442,21 @@ class TestApplyUpdateAction(unittest.TestCase):
         # safe_read call live in shared.py. Patch targets moved with the code:
         # PY_FILES is read from shared's module scope (not monitor's), and
         # safe_read is invoked via shared's import (not monitor's).
+        # Real-file approach (vs. global pathlib.Path.exists patch): create a
+        # tmp repo root with one real file so the existence check passes
+        # without polluting Path.exists for any unrelated code path.
         import monitor
         import shared
-        with patch("monitor._git_cmd", return_value=(0, "ok", "")):
-            with patch.object(shared, "PY_FILES", ("monitor.py",)):
-                with patch("pathlib.Path.exists", return_value=True):
-                    with patch("shared.safe_read", return_value=None) as mock_safe_read:
-                        _apply_update_worker()
-        mock_safe_read.assert_called_once()
-        self.assertIn("syntax errors", monitor._update_result)
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = pathlib.Path(td)
+            (repo_root / "monitor.py").write_text("# stub")
+            with patch("monitor._git_cmd", return_value=(0, "ok", "")):
+                with patch.object(shared, "PY_FILES", ("monitor.py",)):
+                    with patch.object(monitor, "_REPO_ROOT", repo_root):
+                        with patch("shared.safe_read", return_value=None) as mock_safe_read:
+                            _apply_update_worker()
+            mock_safe_read.assert_called_once()
+            self.assertIn("syntax errors", monitor._update_result)
 
     def test_failure(self):
         with patch("monitor._git_cmd", return_value=(1, "", "conflict")):
@@ -627,6 +633,47 @@ class TestApplyUpdateSingletonLock(unittest.TestCase):
                 pass  # may exit after git ops — that is fine for this assertion
 
         mock_run_git.assert_called()
+
+
+class TestCheckPythonVersion(unittest.TestCase):
+    """update.check_python_version is a single early-exit gate; trivial but
+    must not silently regress (e.g. a typo flipping the comparison).
+
+    sys.version_info itself is a non-constructible structseq, so the mock
+    uses a stand-in namedtuple with the same fields (.major/.minor are read
+    by the error-message format string; comparison is delegated to the
+    tuple-ordering protocol).
+    """
+
+    from collections import namedtuple
+    _VI = namedtuple("_VI", "major minor micro releaselevel serial")
+
+    @classmethod
+    def _vi(cls, major, minor):
+        return cls._VI(major, minor, 0, "final", 0)
+
+    def test_below_min_exits_with_code_1(self):
+        import update as _u
+        with patch("update.sys.version_info", self._vi(3, 7)):
+            with self.assertRaises(SystemExit) as cm:
+                _u.check_python_version()
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_at_minimum_does_not_exit(self):
+        import update as _u
+        with patch("update.sys.version_info", self._vi(3, 8)):
+            try:
+                _u.check_python_version()
+            except SystemExit:  # pragma: no cover
+                self.fail("Python at MIN_PYTHON must not trigger sys.exit")
+
+    def test_above_minimum_does_not_exit(self):
+        import update as _u
+        with patch("update.sys.version_info", self._vi(3, 12)):
+            try:
+                _u.check_python_version()
+            except SystemExit:  # pragma: no cover
+                self.fail("Python newer than MIN_PYTHON must not trigger sys.exit")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Audit-cleanup release. Resolves the outstanding P2 + P3 findings from the 24.05.2026 five-dimension audit (REPORT.md backed up to `D:\backups\audit-24.05.2026-cc-aio-mon.zip`). No new features, no user-visible behavior change beyond two niche edges:

1. **Crash log always rotates** — `_install_crash_logger` now passes `always=True` to `rotate_crash_log` so a quick second crash preserves the prior traceback in `.log.1` instead of silently overwriting it.
2. **`pulse.indicator_label` is now public** — renamed from `_indicator_label` because `monitor.render_pulse_modal` was already reaching across the module boundary; the mapping is a stable contract.

## What's in it

**Internal hygiene (P3 ARCH / STYLE):**
- Named time constants `SECONDS_1H` / `5H` / `1D` / `7D` and `HISTORY_RATE_SAMPLES` in `shared.py` replace bare magic numbers in `monitor.py` + `pulse.py`.
- `_MODELS` registry collapsed into one dict literal (was placeholder + `.update()` 900 LOC apart).
- `flush(cols)` is now required (the `cols=None` fallback was unreachable in production).
- `pulse._classify_incident` excludes `bool` from its `isinstance(..., (str, int, float))` check.
- `# noqa: BLE001` annotation on the intentional `_rls_maybe_check` `except Exception` swallow.

**Security (P3 SEC):**
- `.gitignore` extended with `id_ecdsa*`, `.ssh/`, `known_hosts`, `service-account*.json`, `.netrc`, `*.kdbx`, `.aws/credentials`.

**Tests (P2 T-* + P3 TEST):**
- `TestExtractChangelogEntry` — 6 direct cases (middle entry, EOF anchor, missing version, empty input, `max_lines` truncation, regex-metachar escaping).
- `TestContextSuffixHelpers` — 8 cases for `strip_context_suffix` / `compact_context_suffix`.
- `TestCheckPythonVersion` — 3 cases pinning `update.check_python_version` exit behavior (uses a `namedtuple` stand-in for the non-constructible `sys.version_info` structseq).
- `TestSafeRead.test_returns_none_on_permission_error` — pins that any `OSError` returns `None`.
- `TestRotateCrashLog.test_always_rotates_small_file` + `test_always_no_op_when_path_missing`.
- `TestApplyUpdateAction.test_syntax_check_uses_safe_read` no longer patches `pathlib.Path.exists` globally — uses a real tmpdir + stub file.
- `TestCalcRates.test_shared_module_identity` renamed to `test_monitor_and_statusline_alias_shared_calc_rates` with SSoT-intent docstring.

**Baseline: 585 → 605 passing.**

## Test plan

- [x] `py -m py_compile monitor.py statusline.py shared.py update.py pulse.py` — all 5 runtime files compile.
- [x] `py tests.py` — 605 / 605 pass on Windows / 3.12.
- [x] `py monitor.py --list` smoke test — UTF-8 diakritika renders correctly in non-interactive output (NEW-003 regression watch).
- [x] `shared.VERSION = "1.12.2"` is the single source of truth (grep confirmed).
- [x] No bare `18000` / `604800` magic numbers left in runtime — only the named-constant definitions in `shared.py`.
- [x] `pulse.indicator_label("none")` returns `"operational"`; `monitor.render_pulse_modal` uses the public name.
- [ ] CI multi-platform run (Ubuntu / macOS / Windows × 3.8–3.12) — awaiting GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)