### PR TITLE
v1.12.3 — close remaining actionable P2/P3, +3 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## v1.12.3 — 2026-05-25
+
+Second audit-cleanup release. Closes the remaining actionable P2/P3
+findings from the 24.05.2026 audit; the rest stay DEFER with explicit
+triggers (per the audit's own "Nepriorita" / "OK ako je" verdicts on
+those items). No new features, no user-visible behavior change.
+
+**Tests:**
+- **Vague test names renamed (T-P2-3).** 13 occurrences of `test_basic`
+  / `test_success` / `test_failure` across `test_update.py`,
+  `test_statusline.py`, and `test_monitor.py` are now
+  `test_<subject>_<condition>_<expectation>` per the project convention
+  (e.g. `TestGitCmd.test_success` → `test_returns_stripped_stdout_on_zero_rc`).
+  Failure messages are now self-describing.
+- **Defensive `tearDown` for module-level cache state (T-P2-5).**
+  `TestAggregateSessionCost` and `TestAggregateSessionCostSecurity` now
+  explicitly clear `_SESSION_COST_CACHE` in `tearDown` in addition to
+  `setUp`. Closes the audit-noted "drobné riziko" where a mid-test
+  failure could leak cache entries into the next class in the same
+  process.
+- **`pulse._atomic_replace_log` OSError cleanup test (P3-4).** Pins
+  that a simulated `Path.replace` failure swallows the exception
+  (best-effort contract) and unlinks the `.tmp` file so it doesn't
+  leak into `DATA_DIR`.
+- **`is_safe_dir` Windows junction mock tests (P3-3).** Two new tests
+  that mock `st_file_attributes` to exercise the Windows-only reparse-
+  point branch (`shared.py:269-274`) cross-platform: one verifies a
+  junction is rejected, the complement verifies a real directory
+  without the bit is accepted. Previously only native symlinks were
+  exercised, leaving the junction code path unverified on CI.
+
+**Code hygiene:**
+- **`r` / `w` → `cr_inc` / `cw_inc` in `_aggregate_session_cost`
+  (P3 STYLE-002).** The single-letter loop locals visually collided
+  with the module-level `R = "\033[0m"` ANSI reset. Renamed to
+  `in_inc` / `out_inc` / `cr_inc` / `cw_inc` to make the per-record
+  semantics explicit.
+
+**Documentation:**
+- **Type hints on `shared.py` public API (P3 DOC-001).** Added
+  annotations to the helpers the audit specifically called out as
+  "would improve IDE autocomplete for contributors":
+  `safe_read`, `run_git`, `acquire_singleton_lock`, `load_history`,
+  `calc_rates`, plus `extract_changelog_entry`, `parse_ahead_behind`,
+  `check_syntax_after_pull`, `rotate_crash_log`,
+  `strip_context_suffix`, `compact_context_suffix`. Imports
+  `Optional` / `Tuple` / `List` / `Iterable` / `IO` from `typing`
+  (Python 3.8 compatible — no PEP 585 `list[dict]` syntax).
+  No `mypy --strict` in CI; the annotations are documentary.
+
+**Tests:** 608 passing (+3 from this batch).
+
 ## v1.12.2 — 2026-05-25
 
 Audit-cleanup release: outstanding P2 + P3 findings from the 24.05.2026

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
    `unittest discover tests/`, so the `py tests.py` invocation continues to work
    unchanged.
 
-   **Baseline: 605 tests passing (3 skipped on platforms missing optional artifacts).**
+   **Baseline: 608 tests passing (3 skipped on platforms missing optional artifacts).**
    Contributions must not reduce the passing count without explanation. If you add
    tests, put them in the file that matches the module under test — helpers go in
    `test_shared.py`, TUI logic in `test_monitor.py`, and so on.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -55,13 +55,13 @@ Work through these in order before creating any tag.
   python3 tests.py     # macOS / Linux
   ```
   `tests.py` is a thin wrapper that runs `unittest discover tests/`
-  (`tests.py:main()`). Current baseline: **605 passing** (v1.12.2). The new
+  (`tests.py:main()`). Current baseline: **608 passing** (v1.12.3). The new
   release's count must be >= this number unless tests were intentionally
   removed (document the removal in CHANGELOG).
 
 - [ ] **CHANGELOG entry drafted** (see Section 3 for exact format).
   Write the entry for the new version at the top of `CHANGELOG.md`, above the
-  current `## v1.12.2` block. Do not push yet.
+  current `## v1.12.3` block. Do not push yet.
 
 - [ ] **VERSION constant bumped in `shared.py` only.**
   The constant lives at `shared.py:46`:

--- a/monitor.py
+++ b/monitor.py
@@ -1508,15 +1508,17 @@ def _aggregate_session_cost(data):
                 u = msg.get("usage") or {}
                 mid = msg.get("model") or ""
                 pricing = _get_pricing(mid)
-                i = _num(u.get("input_tokens", 0))
-                o = _num(u.get("output_tokens", 0))
-                r = _num(u.get("cache_read_input_tokens", 0))
-                w = _num(u.get("cache_creation_input_tokens", 0))
-                inp += i; out += o; cr += r; cw += w
-                ci += i * pricing["input"] / 1_000_000
-                co += o * pricing["output"] / 1_000_000
-                ccr += r * pricing["cache_read"] / 1_000_000
-                ccw += w * pricing["cache_write"] / 1_000_000
+                # Per-record token deltas — name with cr_inc/cw_inc (not r/w)
+                # to avoid visual collision with module-level `R` ANSI reset.
+                in_inc = _num(u.get("input_tokens", 0))
+                out_inc = _num(u.get("output_tokens", 0))
+                cr_inc = _num(u.get("cache_read_input_tokens", 0))
+                cw_inc = _num(u.get("cache_creation_input_tokens", 0))
+                inp += in_inc; out += out_inc; cr += cr_inc; cw += cw_inc
+                ci += in_inc * pricing["input"] / 1_000_000
+                co += out_inc * pricing["output"] / 1_000_000
+                ccr += cr_inc * pricing["cache_read"] / 1_000_000
+                ccw += cw_inc * pricing["cache_write"] / 1_000_000
                 stu = u.get("server_tool_use") or {}
                 if isinstance(stu, dict):
                     wsr += int(_num(stu.get("web_search_requests", 0)))

--- a/shared.py
+++ b/shared.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import time
 import unicodedata
+from typing import IO, Iterable, List, Optional, Tuple
 
 # Platform-conditional lock primitives used by acquire_singleton_lock().
 if sys.platform == "win32":
@@ -51,7 +52,7 @@ DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.12.2"
+VERSION = "1.12.3"
 
 # File-IPC contract version. Statusline writes this field on every snapshot
 # and history entry; bumped when the JSON shape changes incompatibly. Monitor
@@ -121,12 +122,12 @@ C_DIM = E + "38;2;76;86;106m"
 _CONTEXT_SUFFIX_RE = re.compile(r"\s*\((\d+\w?)\s*context\)")
 
 
-def strip_context_suffix(name):
+def strip_context_suffix(name: str) -> str:
     """Remove '(Nk context)' / '(NM context)' entirely. 'Opus 4.7 (1M context)' -> 'Opus 4.7'."""
     return _CONTEXT_SUFFIX_RE.sub("", name).strip()
 
 
-def compact_context_suffix(name):
+def compact_context_suffix(name: str) -> str:
     """Compact to trailing unit. 'Opus 4.7 (1M context)' -> 'Opus 4.7 1M'."""
     return _CONTEXT_SUFFIX_RE.sub(r" \1", name).strip()
 
@@ -138,7 +139,7 @@ def _num(v, default=0):
         return default
 
 
-def load_history(sid, n=HISTORY_RATE_SAMPLES, data_dir=None):
+def load_history(sid: str, n: int = HISTORY_RATE_SAMPLES, data_dir: Optional[pathlib.Path] = None) -> List[dict]:
     """Read last n JSONL history entries for session `sid`.
 
     Single source of truth for both monitor.py (BRN/CTR dashboard rates) and
@@ -172,7 +173,7 @@ def load_history(sid, n=HISTORY_RATE_SAMPLES, data_dir=None):
     return out
 
 
-def safe_read(path, max_bytes):
+def safe_read(path, max_bytes: int) -> Optional[bytes]:
     """Bounded read — returns bytes or None. Never reads more than max_bytes + 1.
 
     Closes the size TOCTOU gap: caller doesn't have to stat first, and even if
@@ -316,7 +317,7 @@ def ensure_data_dir(d):
 _CHANGELOG_ENTRY_RE_TEMPLATE = r"## v{}\b.*?(?=\n## v|\Z)"
 
 
-def extract_changelog_entry(text, version, max_lines=None):
+def extract_changelog_entry(text: str, version: str, max_lines: Optional[int] = None) -> str:
     """Extract single '## v{version}' section from CHANGELOG text."""
     pattern = _CHANGELOG_ENTRY_RE_TEMPLATE.format(re.escape(version))
     m = re.search(pattern, text, re.DOTALL)
@@ -347,7 +348,7 @@ def _git_env():
     return env
 
 
-def run_git(args, cwd, timeout=15):
+def run_git(args: Iterable[str], cwd, timeout: float = 15) -> "subprocess.CompletedProcess[str]":
     """Safe git invocation with minimal env whitelist.
     Returns subprocess.CompletedProcess. Raises FileNotFoundError if git missing."""
     return subprocess.run(
@@ -366,7 +367,7 @@ def run_git(args, cwd, timeout=15):
 # ---------------------------------------------------------------------------
 
 
-def check_syntax_after_pull(repo_root, py_files=None):
+def check_syntax_after_pull(repo_root: pathlib.Path, py_files: Optional[Iterable[str]] = None) -> List[str]:
     """Compile each .py file under ``repo_root`` to catch syntax errors after
     a self-update. Returns a list of relative filenames that failed to compile
     (empty when all files pass). Files missing from disk are silently skipped;
@@ -393,7 +394,7 @@ def check_syntax_after_pull(repo_root, py_files=None):
     return bad
 
 
-def parse_ahead_behind(rev_list_output):
+def parse_ahead_behind(rev_list_output: str) -> Tuple[int, int]:
     """Parse the output of ``git rev-list --left-right --count HEAD...origin/main``
     and return ``(ahead, behind)``. Raises ValueError if the output cannot be
     parsed into two integers.
@@ -408,7 +409,7 @@ def parse_ahead_behind(rev_list_output):
     return int(parts[0]), int(parts[1])
 
 
-def rotate_crash_log(path, max_bytes=MAX_FILE_SIZE, always=False):
+def rotate_crash_log(path: pathlib.Path, max_bytes: int = MAX_FILE_SIZE, always: bool = False) -> None:
     """Rotate ``path`` to ``path.1`` when size exceeds ``max_bytes``, or
     unconditionally when ``always=True``.
 
@@ -437,7 +438,7 @@ def rotate_crash_log(path, max_bytes=MAX_FILE_SIZE, always=False):
         pass
 
 
-def acquire_singleton_lock(lock_path):
+def acquire_singleton_lock(lock_path) -> Optional[IO]:
     """Try to acquire an exclusive non-blocking file lock at ``lock_path``.
 
     Returns the open file handle on success — the caller MUST keep a strong
@@ -486,7 +487,7 @@ def acquire_singleton_lock(lock_path):
     return fh
 
 
-def calc_rates(hist):
+def calc_rates(hist: List[dict]) -> Tuple[Optional[float], Optional[float]]:
     """Return (brn $/min, ctr %/min) from history, or (None, None) if insufficient data."""
     if len(hist) < 2:
         return None, None

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -243,7 +243,7 @@ class TestCalcRates(unittest.TestCase):
     def _entry(self, t, cost, ctx_pct):
         return {"t": t, "cost": {"total_cost_usd": cost}, "context_window": {"used_percentage": ctx_pct}}
 
-    def test_basic(self):
+    def test_two_entries_compute_per_minute_rates(self):
         hist = [self._entry(1_600_000_000, 0.0, 10.0), self._entry(1_600_000_060, 0.06, 20.0)]
         cpm, xpm = calc_rates(hist)
         self.assertAlmostEqual(cpm, 0.06, places=5)
@@ -1315,6 +1315,14 @@ class TestRenderCostBreakdown(unittest.TestCase):
 class TestAggregateSessionCost(unittest.TestCase):
 
     def setUp(self):
+        _SESSION_COST_CACHE.clear()
+
+    def tearDown(self):
+        # Defensive guard for module-level cache state (audit T-P2-5):
+        # if a test mid-run inserts entries into _SESSION_COST_CACHE and
+        # raises after the assertion fails, the next class in the same
+        # process would inherit them. unittest runs tearDown even on
+        # failure, so this guarantees a clean slate.
         _SESSION_COST_CACHE.clear()
 
     def test_aggregate_session_cost_via_transcript_path(self):
@@ -2535,6 +2543,10 @@ class TestScanTranscriptCacheOnly(unittest.TestCase):
 class TestAggregateSessionCostSecurity(unittest.TestCase):
 
     def setUp(self):
+        _SESSION_COST_CACHE.clear()
+
+    def tearDown(self):
+        # Audit T-P2-5 defensive guard — see TestAggregateSessionCost.tearDown.
         _SESSION_COST_CACHE.clear()
 
     def test_transcript_path_traversal_rejected(self):

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -909,6 +909,41 @@ class TestWorkerLoopCrashRecovery(unittest.TestCase):
         self.assertEqual(snap.get("reason"), "worker crashed")
 
 
+class TestAtomicReplaceLogOSErrorCleanup(unittest.TestCase):
+    """Audit P3-4: pulse._atomic_replace_log has an OSError handler that
+    closes and unlinks the temp file. The branch was not exercised by any
+    test, so a regression (e.g. leaking the temp file or raising) would
+    go undetected."""
+
+    def setUp(self):
+        import pulse
+        self._p = pulse
+        self._tmpdir = tempfile.mkdtemp()
+        self._orig_data = pulse.DATA_DIR
+        self._orig_log = pulse.LOG_PATH
+        pulse.DATA_DIR = pathlib.Path(self._tmpdir)
+        pulse.LOG_PATH = pulse.DATA_DIR / "pulse.jsonl"
+
+    def tearDown(self):
+        import shutil
+        self._p.DATA_DIR = self._orig_data
+        self._p.LOG_PATH = self._orig_log
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_replace_oserror_cleans_temp_and_does_not_raise(self):
+        """When Path.replace raises OSError, the OSError handler must
+        unlink the temp file and swallow the exception (best-effort).
+        Verify no .tmp files leak into DATA_DIR."""
+        # Patch pathlib.Path.replace to raise — exercises the except branch.
+        with patch("pathlib.Path.replace", side_effect=OSError("simulated rename failure")):
+            # Must not raise — the function is best-effort.
+            self._p._atomic_replace_log(["one\n", "two\n"])
+        # Temp file must be cleaned up; LOG_PATH must not exist (replace failed).
+        leftovers = list(self._p.DATA_DIR.glob("*.tmp"))
+        self.assertEqual(leftovers, [], f"temp files leaked: {leftovers}")
+        self.assertFalse(self._p.LOG_PATH.exists(), "LOG_PATH must not exist after failed replace")
+
+
 if __name__ == "__main__":
     result = unittest.main(verbosity=2, exit=False)
     sys.exit(0 if result.result.wasSuccessful() else 1)

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -145,6 +145,33 @@ class TestIsSafeDir(unittest.TestCase):
         finally:
             p.unlink(missing_ok=True)
 
+    def test_windows_junction_rejected_via_reparse_point_bit(self):
+        """Audit P3-3: shared.py:269-274 has a Windows-only branch that
+        rejects junction-style reparse points (FILE_ATTRIBUTE_REPARSE_POINT
+        = 0x400). Native testing requires admin to create a junction, so
+        mock sys.platform + the lstat result instead. Runs cross-platform."""
+        import pathlib
+        # Mock stat result: directory mode + reparse point attribute set.
+        fake_st = MagicMock()
+        fake_st.st_mode = 0o040000  # S_IFDIR — passes the directory check
+        fake_st.st_file_attributes = 0x400  # FILE_ATTRIBUTE_REPARSE_POINT
+        fake_path = MagicMock(spec=pathlib.Path)
+        fake_path.lstat.return_value = fake_st
+        with patch("shared.sys.platform", "win32"):
+            self.assertFalse(shared.is_safe_dir(fake_path))
+
+    def test_windows_real_directory_without_reparse_bit_accepted(self):
+        """Complement to the junction test — same Windows branch must
+        return True when the reparse-point bit is clear."""
+        import pathlib
+        fake_st = MagicMock()
+        fake_st.st_mode = 0o040000  # S_IFDIR
+        fake_st.st_file_attributes = 0  # no reparse point
+        fake_path = MagicMock(spec=pathlib.Path)
+        fake_path.lstat.return_value = fake_st
+        with patch("shared.sys.platform", "win32"):
+            self.assertTrue(shared.is_safe_dir(fake_path))
+
 
 # ---------------------------------------------------------------------------
 # TestEnsureDataDir — shared.ensure_data_dir()

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -95,7 +95,7 @@ class TestGetTerminalWidth(unittest.TestCase):
 # ---------------------------------------------------------------------------
 class TestSegModel(unittest.TestCase):
 
-    def test_basic(self):
+    def test_renders_display_name_with_consistent_vlen(self):
         text, vl = seg_model(_full_data())
         self.assertEqual(vl, _vlen(text))
         self.assertIn("Opus 4", _ANSI_RE.sub("", text))
@@ -114,7 +114,7 @@ class TestSegModel(unittest.TestCase):
 
 class TestSegCtx(unittest.TestCase):
 
-    def test_basic(self):
+    def test_renders_ctx_pct_with_token_count(self):
         text, vl = seg_ctx(_full_data())
         self.assertEqual(vl, _vlen(text))
         plain = _ANSI_RE.sub("", text)
@@ -132,7 +132,7 @@ class TestSegCtx(unittest.TestCase):
 
 class TestSeg5hl(unittest.TestCase):
 
-    def test_basic(self):
+    def test_renders_5hl_label_with_consistent_vlen(self):
         text, vl = seg_5hl(_full_data())
         self.assertEqual(vl, _vlen(text))
         self.assertIn("5HL", _ANSI_RE.sub("", text))
@@ -190,7 +190,7 @@ class TestSeg5hl(unittest.TestCase):
 
 class TestSeg7dl(unittest.TestCase):
 
-    def test_basic(self):
+    def test_renders_7dl_label_with_consistent_vlen(self):
         text, vl = seg_7dl(_full_data())
         self.assertEqual(vl, _vlen(text))
         self.assertIn("7DL", _ANSI_RE.sub("", text))
@@ -225,7 +225,7 @@ class TestSeg7dl(unittest.TestCase):
 
 class TestSegCost(unittest.TestCase):
 
-    def test_basic(self):
+    def test_renders_cst_label_with_dollar_amount(self):
         text, vl = seg_cost(_full_data())
         self.assertEqual(vl, _vlen(text))
         self.assertIn("CST", _ANSI_RE.sub("", text))
@@ -243,7 +243,7 @@ class TestSegCost(unittest.TestCase):
 
 class TestSegBrn(unittest.TestCase):
 
-    def test_basic(self):
+    def test_renders_brn_label_with_consistent_vlen(self):
         text, vl = seg_brn(0.0512)
         self.assertEqual(vl, _vlen(text))
         self.assertIn("BRN", _ANSI_RE.sub("", text))

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -276,7 +276,7 @@ class TestUpdate(unittest.TestCase):
 # ---------------------------------------------------------------------------
 class TestGitCmd(unittest.TestCase):
 
-    def test_success(self):
+    def test_returns_stripped_stdout_on_zero_rc(self):
         import subprocess as sp
         completed = sp.CompletedProcess(args=["git"], returncode=0, stdout="ok\n", stderr="")
         with patch("monitor.run_git", return_value=completed):
@@ -350,12 +350,12 @@ class TestUpdateChecks(unittest.TestCase):
 # ---------------------------------------------------------------------------
 class TestGetNewCommits(unittest.TestCase):
 
-    def test_success(self):
+    def test_splits_stdout_into_commit_lines_on_zero_rc(self):
         with patch("monitor._git_cmd", return_value=(0, "abc feat\ndef fix", "")):
             result = _get_new_commits()
         self.assertEqual(result, ["abc feat", "def fix"])
 
-    def test_failure(self):
+    def test_returns_empty_list_on_nonzero_rc(self):
         with patch("monitor._git_cmd", return_value=(1, "", "error")):
             result = _get_new_commits()
         self.assertEqual(result, [])
@@ -427,7 +427,7 @@ class TestApplyUpdateAction(unittest.TestCase):
         else:
             os.environ["CC_AIO_MON_NO_UPDATE_CHECK"] = self._orig_env
 
-    def test_success(self):
+    def test_zero_rc_with_valid_syntax_marks_complete(self):
         # Test the synchronous worker directly (not the thread-spawning wrapper)
         with patch("monitor._git_cmd", return_value=(0, "ok", "")):
             with patch("pathlib.Path.exists", return_value=True):
@@ -458,7 +458,7 @@ class TestApplyUpdateAction(unittest.TestCase):
             mock_safe_read.assert_called_once()
             self.assertIn("syntax errors", monitor._update_result)
 
-    def test_failure(self):
+    def test_nonzero_rc_marks_failed_with_stderr(self):
         with patch("monitor._git_cmd", return_value=(1, "", "conflict")):
             _apply_update_worker()
 


### PR DESCRIPTION
## Summary

Second audit-cleanup release. Closes the remaining actionable P2/P3 findings from the 24.05.2026 audit that v1.12.2 left open; the rest stay DEFER with explicit triggers (matching the audit's own *"Nepriorita"* / *"OK ako je"* verdicts on those items).

**No new features, no user-visible behavior change.**

## What's in it

**Tests (+3 new, 13 renamed, 2 defensive):**
- **T-P2-3** — 13 vague `test_basic` / `test_success` / `test_failure` names across `test_update.py`, `test_statusline.py`, `test_monitor.py` renamed to `test_<subject>_<condition>_<expectation>` (e.g. `TestGitCmd.test_success` → `test_returns_stripped_stdout_on_zero_rc`). Failure messages self-describe what regressed.
- **T-P2-5** — `TestAggregateSessionCost` + `TestAggregateSessionCostSecurity` now have explicit `tearDown` clearing `_SESSION_COST_CACHE`. Closes audit-noted "drobné riziko" of cache leakage on mid-test failure.
- **P3-4** — new `TestAtomicReplaceLogOSErrorCleanup` pins that simulated `Path.replace` failure unlinks the `.tmp` file and swallows the exception.
- **P3-3** — two new `is_safe_dir` Windows-junction mock tests exercise the `FILE_ATTRIBUTE_REPARSE_POINT` branch cross-platform (junction rejected, real dir without bit accepted).

**Code hygiene:**
- **P3 STYLE-002** — `r` / `w` cache vars in `_aggregate_session_cost` renamed to `cr_inc` / `cw_inc` (with `in_inc` / `out_inc`) to avoid visual collision with module-level `R = "\033[0m"` ANSI reset.

**Documentation:**
- **P3 DOC-001** — type hints added to 11 `shared.py` public helpers: `safe_read`, `run_git`, `acquire_singleton_lock`, `load_history`, `calc_rates`, `extract_changelog_entry`, `parse_ahead_behind`, `check_syntax_after_pull`, `rotate_crash_log`, `strip_context_suffix`, `compact_context_suffix`. Python 3.8 compatible (`Optional` / `Tuple` / `List` / `Iterable` / `IO` from `typing`, no PEP 585 `list[dict]` syntax). No `mypy --strict` in CI — annotations are documentary.

**Baseline: 605 → 608 passing (+3).**

## What stays DEFER (explicit per audit rationale)

These are NOT done in this release because the audit itself recommended against doing them:
- **P1-4** cost-aggregator daemon — audit: *"P1 ak má užívateľ veľa aktívnych sessions, inak P2"*. 4th daemon thread adds complexity without user signal.
- **SIZE-001** `monitor.main()` 309 LOC split — audit: *"vysoký risk pre 15+ lokálnych state premenných, žiadne test coverage pre flow control"*.
- **P-P2-1..5** dirty-flag render / diff render / ANSI state-machine — audit per item: *"Nepriorita"* / *"OK ako je"* / *"Trade-off nestojí za to"* / *"Negligible"*.
- **P3 SEC GPG signature** — out of scope for stdlib-only project.

## Test plan

- [x] `py -m py_compile monitor.py statusline.py shared.py update.py pulse.py` — all 5 runtime files compile.
- [x] `py tests.py` — 608 / 608 pass on Windows / 3.12.
- [x] `shared.VERSION == "1.12.3"`.
- [ ] CI multi-platform run — awaiting GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)