### PR TITLE
chore(gitignore): exclude .full-review/ skill workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ notes.md
 
 # Audit tooling — LOCAL ONLY, must never reach GitHub
 docs/audits/
+.full-review/


### PR DESCRIPTION
## Summary

The `comprehensive-review:full-review` skill writes a `.full-review/` workspace directory (state.json + per-phase intermediate reports) at the repo root while running. Audit outputs are copied to the project-level `Audits/` folder per vault conventions; the workspace itself is ephemeral and shouldn't reach GitHub.

One-line addition to `.gitignore` alongside the existing `docs/audits/` exclusion.

## Test plan

- [x] `git status` confirms `.full-review/` is now ignored.
- [ ] CI multi-platform run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)