### PR TITLE
fix(shared): calc_rates tolerates explicit JSON null in cost/context_window

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,7 +66,7 @@ by `build_line()` when the terminal is too narrow. On Windows, terminal width
 is queried via `CONOUT$` because Claude Code runs this script with all file
 descriptors piped (`_get_terminal_width`).
 
-**monitor.py** — Entry point 2 (interactive TUI). ~2 670 LOC. Owns the event
+**monitor.py** — Entry point 2 (interactive TUI). ~2 900 LOC. Owns the event
 loop, all `render_*` functions, the session picker, and three daemon worker
 threads (see Section 5). The crash logger (`_install_crash_logger`) writes
 uncaught exceptions to `monitor-crash.log` because the alt-screen buffer would

--- a/monitor.py
+++ b/monitor.py
@@ -2895,7 +2895,7 @@ def main():
                     ),
                     cols,
                 )
-            except (TypeError, ValueError, KeyError, ZeroDivisionError, OverflowError, OSError) as e:
+            except (TypeError, ValueError, KeyError, AttributeError, ZeroDivisionError, OverflowError, OSError) as e:
                 _render_errors += 1
                 if _render_errors <= 3:
                     sys.stderr.write(f"render error #{_render_errors}: {e}\n")

--- a/shared.py
+++ b/shared.py
@@ -501,10 +501,11 @@ def calc_rates(hist: List[dict]) -> Tuple[Optional[float], Optional[float]]:
     dt = t1 - t0
     if dt < 10:
         return None, None
-    c0 = _num(hist[0].get("cost", {}).get("total_cost_usd"))
-    c1 = _num(hist[-1].get("cost", {}).get("total_cost_usd"))
-    x0 = _num(hist[0].get("context_window", {}).get("used_percentage"))
-    x1 = _num(hist[-1].get("context_window", {}).get("used_percentage"))
+    # `or {}` handles explicit JSON null on disk (default {} only triggers on missing key).
+    c0 = _num((hist[0].get("cost") or {}).get("total_cost_usd"))
+    c1 = _num((hist[-1].get("cost") or {}).get("total_cost_usd"))
+    x0 = _num((hist[0].get("context_window") or {}).get("used_percentage"))
+    x1 = _num((hist[-1].get("context_window") or {}).get("used_percentage"))
     brn = (c1 - c0) / dt * 60 if c1 >= c0 else None
     ctr = (x1 - x0) / dt * 60 if x1 >= x0 else None
     return brn, ctr

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -294,6 +294,40 @@ class TestCalcRates(unittest.TestCase):
         self.assertIs(m_cr, shared.calc_rates)
         self.assertIs(sl_calc_rates, shared.calc_rates)
 
+    # H-1 regression: explicit JSON null on cost/context_window must not
+    # AttributeError. Statusline.write_shared_state always emits dict shapes,
+    # but a corrupt or manually-edited .jsonl can carry `"cost": null` — the
+    # render loop must keep running, so calc_rates degrades to the same
+    # default-zero path as a missing key (None becomes 0 via _num default).
+    def test_explicit_null_cost_does_not_crash(self):
+        hist = [
+            {"t": 1_600_000_000, "cost": None, "context_window": {"used_percentage": 10.0}},
+            {"t": 1_600_000_060, "cost": None, "context_window": {"used_percentage": 20.0}},
+        ]
+        brn, ctr = calc_rates(hist)
+        self.assertEqual(brn, 0.0)
+        self.assertAlmostEqual(ctr, 10.0, places=5)
+
+    def test_explicit_null_context_window_does_not_crash(self):
+        hist = [
+            {"t": 1_600_000_000, "cost": {"total_cost_usd": 0.0}, "context_window": None},
+            {"t": 1_600_000_060, "cost": {"total_cost_usd": 0.06}, "context_window": None},
+        ]
+        brn, ctr = calc_rates(hist)
+        self.assertAlmostEqual(brn, 0.06, places=5)
+        self.assertEqual(ctr, 0.0)
+
+    def test_mixed_null_and_present_cost_does_not_crash(self):
+        # Most realistic corruption: only one endpoint is null. Pre-fix this
+        # path triggered `None.get(...)` AttributeError on the null side.
+        hist = [
+            {"t": 1_600_000_000, "cost": None, "context_window": None},
+            {"t": 1_600_000_060, "cost": {"total_cost_usd": 0.06}, "context_window": {"used_percentage": 20.0}},
+        ]
+        brn, ctr = calc_rates(hist)
+        self.assertAlmostEqual(brn, 0.06, places=5)
+        self.assertAlmostEqual(ctr, 20.0, places=5)
+
 
 # ---------------------------------------------------------------------------
 # _num


### PR DESCRIPTION
## Problem
`calc_rates` read `cost` / `context_window` via `.get(key, {})`, which only defaults on a **missing** key. A corrupt or hand-edited `.jsonl` can carry an explicit `"cost": null` / `"context_window": null`, so `None.get(...)` raised `AttributeError` inside the render loop.

## Fix
- **shared.py**: coalesce with `or {}` so an explicit `null` degrades to the same default-zero path as a missing key.
- **monitor.py**: add `AttributeError` to the render-loop `except` clause (defense-in-depth).
- **tests/test_monitor.py**: +3 regression tests (explicit-null cost, explicit-null context_window, mixed null/present).
- **docs/ARCHITECTURE.md**: refresh monitor.py LOC (~2670 → ~2900).

## Test
`python3 -m unittest tests.test_monitor` → **340 tests OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)