### PR TITLE
chore(release): bump to v1.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.12.4 — 2026-05-30
+
+**Bug fixes:**
+- **`calc_rates` no longer crashes the render loop on an explicit JSON `null`
+  `cost` / `context_window`.** `shared.calc_rates` read these via
+  `.get(key, {})`, which only substitutes the default for a *missing* key — an
+  explicit `"cost": null` / `"context_window": null` in a corrupt or
+  hand-edited `.jsonl` reached `None.get(...)` and raised `AttributeError`
+  inside `monitor.main()`'s per-frame render. The lookups now coalesce with
+  `or {}`, so an explicit null degrades to the same default-zero path as a
+  missing key (`shared.py:calc_rates`).
+- **Monitor render loop now also catches `AttributeError`.** The per-frame
+  `except` in `monitor.main()` adds `AttributeError` to the existing
+  `TypeError`/`ValueError`/`KeyError`/… set, so any future null-shape
+  regression degrades to a counted render error instead of tearing down the
+  alt-screen TUI.
+
+**Tests:** 611 passing (+3).
+
 ## v1.12.3 — 2026-05-25
 
 Second audit-cleanup release. Closes the remaining actionable P2/P3

--- a/shared.py
+++ b/shared.py
@@ -52,7 +52,7 @@ DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.12.3"
+VERSION = "1.12.4"
 
 # File-IPC contract version. Statusline writes this field on every snapshot
 # and history entry; bumped when the JSON shape changes incompatibly. Monitor


### PR DESCRIPTION
Release **v1.12.4** (PATCH). Bumps `VERSION` in `shared.py` and adds the CHANGELOG entry for the crash fix shipped in #61.

## CHANGELOG (v1.12.4)
**Bug fixes:**
- `calc_rates` no longer crashes the render loop on an explicit JSON `null` `cost` / `context_window` (coalesce with `or {}`).
- Monitor render loop now also catches `AttributeError` (defense-in-depth).

**Tests:** 611 passing (+3).

Per `docs/RELEASE.md`: tag `v1.12.4` + GitHub release follow once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)