### PR TITLE
fix(monitor): v1.12.5 — audit #3 remediation

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -68,7 +68,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         echo "BLOCKED: Stripe key pattern (sk_live/sk_test/rk_live/pk_live) in diff" >&2
         fail=1
     fi
-    if echo "$diff_text" | grep -qE -- '-----BEGIN (RSA|DSA|EC|OPENSSH|PGP) PRIVATE KEY-----'; then
+    if echo "$diff_text" | grep -qE -- '-----BEGIN ((RSA|DSA|EC|OPENSSH|PGP) PRIVATE KEY|PRIVATE KEY|ENCRYPTED PRIVATE KEY)-----'; then
         echo "BLOCKED: Private key block in diff" >&2
         fail=1
     fi

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Run Bandit
         # File list sourced from shared.PY_FILES (single source of truth — see tests.yml compile step).
         run: bandit -r $(python -c "from shared import PY_FILES; print(' '.join(PY_FILES))") -f sarif -o bandit.sarif --severity-level medium || true
+      - name: Verify Bandit produced a report
+        # `|| true` above keeps findings non-fatal (triaged via code-scanning),
+        # but must not mask a scanner crash — fail if no SARIF was written.
+        run: test -s bandit.sarif
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,83 @@
+name: Release Smoke (self-update E2E)
+
+# End-to-end smoke test for the self-update happy path (CI-H-1). Self-update is
+# commit-driven: update.py / monitor.py run `git pull --ff-only origin main` and
+# read the version from `origin/main:shared.py`, so users pull whatever lands on
+# main HEAD. This job simulates a real release-to-release update: it rewinds the
+# checkout to the PREVIOUS tag (an "outdated install"), then runs the actual
+# update.py --apply path and verifies the updated tree compiles and passes the
+# full suite. Catches regressions in the update machinery itself before users
+# auto-pull a broken release.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.py"
+      - ".github/workflows/release-smoke.yml"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  self-update-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # full history + tags needed to rewind to a prior release
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Identify previous release tag
+        id: prev
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          # update.py requires being ON the main branch (rejects detached HEAD).
+          git checkout -B main "$GITHUB_SHA"
+          # Most recent tag reachable from the parent commit = the prior release.
+          PREV="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
+          if [ -z "$PREV" ]; then
+            echo "No previous tag found — skipping self-update smoke (nothing to update from)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Previous release tag: $PREV"
+            echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Simulate outdated install (rewind main to previous tag)
+        if: steps.prev.outputs.skip != 'true'
+        env:
+          PREV: ${{ steps.prev.outputs.prev }}
+        run: |
+          # Rewind local main behind origin/main (which still points at the
+          # pushed HEAD) — exactly the state of a user one release behind.
+          git reset --hard "$PREV"
+          python -c "import shared; print('Simulated install at VERSION', shared.VERSION)"
+
+      - name: Read-only update check detects an available update
+        if: steps.prev.outputs.skip != 'true'
+        run: |
+          # Non-apply mode exits 0 whether up-to-date or behind; assert it ran
+          # cleanly and reported a remote version.
+          python update.py | tee check.out
+          grep -q "Latest:" check.out
+
+      - name: Apply self-update (git pull --ff-only + syntax check)
+        if: steps.prev.outputs.skip != 'true'
+        run: |
+          python update.py --apply | tee apply.out
+          grep -q "Update complete." apply.out
+          grep -q "Syntax check passed" apply.out
+
+      - name: Updated tree matches origin/main HEAD
+        if: steps.prev.outputs.skip != 'true'
+        run: |
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+          python -c "import importlib, shared; importlib.reload(shared); print('Updated to VERSION', shared.VERSION)"
+
+      - name: Full suite passes on the updated tree
+        if: steps.prev.outputs.skip != 'true'
+        run: python tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v1.12.5 — 2026-05-30
+
+**Bug fixes:**
+- **Pulse "PULSE ERROR" no longer shows stale "all green" data.** When the
+  background Pulse worker hits an unexpected exception, its last-resort handler
+  now clears the volatile snapshot fields (incidents, components, latency,
+  scores, indicator) instead of leaving values from the last healthy fetch in
+  place. A crash during a real outage no longer renders an error verdict next
+  to stale "operational" incidents/components (`pulse.py:_crash_snapshot`).
+- **Self-update can no longer be interrupted mid-pull.** Pressing `q` while a
+  self-update is applying is now ignored until the worker finishes its
+  post-pull syntax check, so quitting can't kill the daemon after
+  `git pull --ff-only` has rewritten files but before the integrity check runs
+  (`monitor.py` event loop + `_apply_update_action`).
+
+**Security hardening:**
+- **IPC schema gate.** `monitor.load_state()` now refuses a session snapshot
+  tagged with a newer `_schema_version` than the running build understands
+  (degrades to "no data") rather than risk misreading an incompatible shape;
+  missing or older tags stay readable (`monitor.py:load_state`).
+
+**Tests:** 617 passing (+6).
+
 ## v1.12.4 — 2026-05-30
 
 **Bug fixes:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
    `unittest discover tests/`, so the `py tests.py` invocation continues to work
    unchanged.
 
-   **Baseline: 608 tests passing (3 skipped on platforms missing optional artifacts).**
+   **Baseline: 617 tests passing (3 skipped on platforms missing optional artifacts).**
    Contributions must not reduce the passing count without explanation. If you add
    tests, put them in the file that matches the module under test — helpers go in
    `test_shared.py`, TUI logic in `test_monitor.py`, and so on.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Optional first step: run `check-requirements.ps1` (Windows) or `check-requiremen
 
 | Platform | Guide |
 |----------|-------|
-| [Windows](setup-windows.md) | Python Launcher (`py`), Windows Terminal, PowerShell |
-| [macOS](setup-macos.md) | python3, Terminal.app or iTerm2 |
-| [Linux](setup-linux.md) | python3, any truecolor terminal |
+| [Windows](docs/setup-windows.md) | Python Launcher (`py`), Windows Terminal, PowerShell |
+| [macOS](docs/setup-macos.md) | python3, Terminal.app or iTerm2 |
+| [Linux](docs/setup-linux.md) | python3, any truecolor terminal |
 
 ## Features
 
@@ -78,7 +78,7 @@ Optional first step: run `check-requirements.ps1` (Windows) or `check-requiremen
 - **Security hardened** — session ID regex validation (`[a-zA-Z0-9_-]{1,128}`) with Windows reserved-device-name rejection (`CON`/`PRN`/`AUX`/`NUL`/`COM0-9`/`LPT0-9`, case-insensitive), C0/C1 control character sanitization, atomic writes via `NamedTemporaryFile`, symlink/junction rejection on the temp data directory and `~/.claude/projects/`, transcript containment checks, and bounded reads for JSON, JSONL, transcripts, Pulse responses, and post-update source checks.
 - **Singleton lock** — only one interactive `py monitor.py` can run at a time; a second attempt exits with a clear error pointing at `$TMPDIR/claude-aio-monitor/monitor.lock`. The `--list` mode is exempt.
 - **Crash-log rotation** — `monitor-crash.log` rotates to `.log.1` at 1 MB so repeated crashes don't fill the disk.
-- **File-IPC schema versioning** — snapshots and history entries now carry `_schema_version` for forward-compatibility; see [docs/FILE-IPC-CONTRACT.md](FILE-IPC-CONTRACT.md).
+- **File-IPC schema versioning** — snapshots and history entries carry `_schema_version`; `monitor.load_state()` refuses snapshots newer than it understands. See [docs/FILE-IPC-CONTRACT.md](docs/FILE-IPC-CONTRACT.md).
 - **Test suite reorganization** — tests are now under `tests/`; existing `py tests.py` invocations still work via discovery.
 
 ## Session States
@@ -264,9 +264,9 @@ export CLAUDE_STATUS_CRIT=90
 
 Platform-specific troubleshooting is in the setup guides:
 
-- [Windows — Troubleshooting](setup-windows.md#troubleshooting)
-- [macOS — Troubleshooting](setup-macos.md#troubleshooting)
-- [Linux — Troubleshooting](setup-linux.md#troubleshooting)
+- [Windows — Troubleshooting](docs/setup-windows.md#troubleshooting)
+- [macOS — Troubleshooting](docs/setup-macos.md#troubleshooting)
+- [Linux — Troubleshooting](docs/setup-linux.md#troubleshooting)
 
 ## Updating
 
@@ -287,6 +287,8 @@ py update.py --apply          # check + git pull
 ```
 
 The script is **read-only by default** — it shows you what would change (version, new commits, CHANGELOG preview) and only pulls when you add `--apply`. It aborts safely if your working tree is dirty, you're on a different branch, or history has diverged.
+
+**From inside the monitor:** you can also update without leaving the TUI — press `u` to open the update manager (current vs remote version, new commits, changelog preview, safety warnings), then `a` to apply. It runs the same `git pull --ff-only` + post-pull syntax check as `update.py --apply`; restart the monitor afterwards to load the new code.
 
 **Rollback safety:** before each `--apply` pull, a `pre-update-YYYYMMDD-HHMMSS` git tag is created automatically. If anything breaks after the update, recover with:
 
@@ -312,9 +314,9 @@ After updating, restart Claude Code to pick up the new statusline. Optionally re
 
 ## Documentation
 
-- [docs/ARCHITECTURE.md](ARCHITECTURE.md) — contributor-oriented architecture overview
-- [docs/FILE-IPC-CONTRACT.md](FILE-IPC-CONTRACT.md) — schema of the two-process file IPC
-- [docs/RELEASE.md](RELEASE.md) — release process checklist
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — contributor-oriented architecture overview
+- [docs/FILE-IPC-CONTRACT.md](docs/FILE-IPC-CONTRACT.md) — schema of the two-process file IPC
+- [docs/RELEASE.md](docs/RELEASE.md) — release process checklist
 - [.github/SECURITY.md](.github/SECURITY.md) — security policy
 
 ## Contributing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # CC AIO MON — Architecture Overview
 
-> v1.12.0 · Target reader: new contributor who just cloned the repo.
+> v1.12.4 · Target reader: new contributor who just cloned the repo.
 > Goal: understand "where is what and how do things relate" in ~10 minutes.
 > For the full feature reference see [README.md](../README.md).
 > For the IPC field schema see [FILE-IPC-CONTRACT.md](FILE-IPC-CONTRACT.md).
@@ -152,14 +152,14 @@ CHANGELOG entry.
 
 ## 5. Threading Model in monitor.py
 
-`monitor.main()` runs a single-threaded event loop (the `while True:` at
-line ~2456). Three daemon threads run concurrently:
+`monitor.main()` runs a single-threaded event loop (the `while True:` loop in
+`main()`). Three daemon threads run concurrently:
 
 | Thread | Spawned by | Purpose |
 |---|---|---|
 | `pulse-worker` | `pulse.start_pulse_worker()` | Fetch Anthropic status + ping API every 30 s |
-| `rls-check` (anonymous) | `_maybe_trigger_rls_check()` | Check GitHub for new release once per hour |
-| `update-apply` (anonymous) | `_start_apply_update()` | Run `git pull --ff-only` when user presses `a` |
+| `rls-check` (anonymous) | `_rls_maybe_check()` | Check GitHub for new release once per hour |
+| `update-apply` | `_apply_update_action()` | Run `git pull --ff-only` when user presses `a` |
 
 All three threads are `daemon=True`: they are killed automatically when the
 main thread exits, so they can never block the terminal restore or hang the
@@ -179,8 +179,16 @@ process on `q`.
   it is an OS-level file lock held via `msvcrt.locking` / `fcntl.flock` for
   the process lifetime. Python must not GC it, hence the module-level reference.
 
-Inside `pulse.py`, `_snapshot_lock` and `_history_lock` guard the pulse
-snapshot dict and the rolling score/latency deques respectively.
+**Lock inventory (`pulse.py`):**
+
+- `_snapshot_lock` (`threading.Lock`) — guards the `_snapshot` dict (the public
+  IPC snapshot) shared between the pulse worker and the main render thread.
+- `_worker_lock` (`threading.Lock`) — guards the `_worker_started` flag so
+  `start_pulse_worker()` launches exactly one daemon (idempotent start).
+- `_history_lock` (`threading.Lock`) — guards the rolling score / latency
+  deques used for median smoothing and p50/p95 percentiles.
+- `_log_lock` (`threading.Lock`) — serializes the atomic rewrites of
+  `pulse.jsonl` during startup cleanup and runtime rotation.
 
 The main loop never blocks on network I/O. Every outbound call (status page,
 API ping, git fetch, git pull) is confined to a daemon thread, so the 50 ms
@@ -270,6 +278,15 @@ with a human-readable error pointing to the lock file. The lock file contains
 the holder's PID for diagnosis. `--list` mode is intentionally exempt because
 it is a one-shot non-interactive read.
 
+*Asymmetric lock-dir-failure behavior (by design):* if `ensure_data_dir()`
+fails (e.g. an attacker-owned `$TMPDIR/claude-aio-monitor/`), the two entry
+points diverge deliberately. `update.py --apply` prints a warning and proceeds
+without the singleton guard (best-effort — a self-update should not be blocked
+by a transient dir issue). `monitor.py` proceeds **silently** without the lock,
+because it has not yet entered the alt-screen and a stderr warning would be
+clobbered by the TUI init; the singleton guard is a convenience there, not a
+safety invariant. Neither path treats lock-dir failure as fatal.
+
 **Crash-log rotation.** `_install_crash_logger()` calls
 `shared.rotate_crash_log(log_path, always=True)` before each crash write.
 The previous traceback is always preserved as `monitor-crash.log.1` even
@@ -279,9 +296,12 @@ quick succession no longer overwrite each other. The default
 any caller that only cares about disk-growth bounds.
 
 **File-IPC schema version.** `shared.SCHEMA_VERSION = 1` is stamped into every
-snapshot and JSONL entry by `statusline.write_shared_state()`. Monitor reads all
-fields via `dict.get()` so old snapshots on disk are silently tolerated. The
-version field exists to make future incompatible shape changes detectable.
+snapshot and JSONL entry by `statusline.write_shared_state()`. `monitor.load_state()`
+gates on it: a snapshot tagged with a version *newer* than the running build is
+treated as unreadable (degrades to `None`) instead of risking a misread of an
+incompatible shape. Missing or older tags default to `0` and stay readable, so
+pre-versioning snapshots left on disk after a `git pull` are tolerated. Bump the
+constant when the JSON shape changes incompatibly.
 
 Two duplicate code paths were also consolidated: `shared.check_syntax_after_pull()`
 replaces byte-for-byte copies in `monitor._apply_update_worker` and
@@ -294,11 +314,11 @@ for `git rev-list --left-right --count` output in both files.
 
 | Goal | Start here |
 |---|---|
-| Change how burn rate or context rate is computed | `shared.calc_rates()` (shared.py:490) — reads last HISTORY_RATE_SAMPLES JSONL history entries |
-| Change hardcoded model pricing | `monitor.py:_aggregate_session_cost()` (line 1269) and the per-model rate dicts above it |
-| Add a field to the IPC snapshot | `statusline.py:write_shared_state()` (line 278) → add field to `snapshot`/`entry` dict → bump `shared.SCHEMA_VERSION` |
-| Add a new TUI modal | `monitor.py:render_frame()` (line 833) dispatches to `render_*` functions; add a new `render_xyz()` and wire a key in the event loop |
-| Add a statusline segment | Add a `seg_xyz()` function in `statusline.py` (see `seg_model`, `seg_ctx`, etc.) and insert it into the `all_segs` list in `build_line()` (line 198) |
+| Change how burn rate or context rate is computed | `shared.calc_rates()` — reads last `HISTORY_RATE_SAMPLES` JSONL history entries |
+| Change hardcoded model pricing | `monitor._aggregate_session_cost()` and the per-model rate dicts above it |
+| Add a field to the IPC snapshot | `statusline.write_shared_state()` → add field to `snapshot`/`entry` dict → bump `shared.SCHEMA_VERSION` (and extend `pulse.PulseSnapshot` if it is a pulse field) |
+| Add a new TUI modal | `monitor.render_frame()` dispatches to `render_*` functions; add a new `render_xyz()` and wire a key in the event loop |
+| Add a statusline segment | Add a `seg_xyz()` function in `statusline.py` (see `seg_model`, `seg_ctx`, etc.) and insert it into the `all_segs` list in `build_line()` |
 | Change the Anthropic Pulse scoring weights | `pulse.py` constants `_W_INDICATOR`, `_W_INCIDENTS`, `_W_LATENCY` and `_INDICATOR_SCORE` / `_IMPACT_DEDUCT` dicts |
-| Add a new Python file to the project | Append the filename to `shared.PY_FILES` (shared.py:107) — this propagates to the post-update syntax check and the compile-check in the test suite |
+| Add a new Python file to the project | Append the filename to `shared.PY_FILES` — this propagates to the post-update syntax check and the compile-check in the test suite |
 | Understand the session file format | `statusline.py:write_shared_state()` writes it; `monitor.py:load_state()` reads it; field names mirror the Claude Code statusline JSON protocol keys |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,7 +25,7 @@ If you add a new env var, add it here in the same commit.
 
 - **Type:** flag (`"1"` disables, anything else enables)
 - **Default:** unset → release-check worker enabled
-- **Read by:** `monitor.py:590` (`_rls_maybe_check`)
+- **Read by:** `monitor.py` (`_rls_maybe_check`)
 - **Effect:** disables the hourly background `git fetch` + remote-version
   poll that powers the `RLS` (Release Status) line and the update modal's
   "new version available" notification.
@@ -37,7 +37,7 @@ If you add a new env var, add it here in the same commit.
 
 - **Type:** flag (`"1"` disables, anything else enables)
 - **Default:** unset → Pulse worker enabled
-- **Read by:** `monitor.py:2562` (`main`)
+- **Read by:** `monitor.py` (`main`)
 - **Effect:** suppresses the `pulse.py` background thread that probes
   `status.claude.com` + the Anthropic API ping endpoint. The `STB`
   (Stability) modal becomes unavailable.
@@ -56,7 +56,7 @@ shells; new thresholds go under `CC_AIO_MON_*`.
 
 - **Type:** float (percent, 0–100)
 - **Default:** `50.0`
-- **Read by:** `shared.py:88` → exported as `shared.WARN_PCT`
+- **Read by:** `shared.py` → exported as `shared.WARN_PCT`
 - **Effect:** percentage threshold at which `CTX` / `5HL` / `7DL` / `CTR`
   bars flip from green to yellow.
 - **Parser:** `shared._env_pct` — invalid / empty values silently fall back
@@ -66,16 +66,16 @@ shells; new thresholds go under `CC_AIO_MON_*`.
 
 - **Type:** float (percent, 0–100)
 - **Default:** `80.0`
-- **Read by:** `shared.py:89` → exported as `shared.CRIT_PCT`
+- **Read by:** `shared.py` → exported as `shared.CRIT_PCT`
 - **Effect:** percentage threshold at which the same bars flip from yellow
   to red. Also drives the `!CTX>X%` warning glyph on the dashboard
-  (`monitor.py:988`).
+  (`monitor.py`).
 
 ### `CLAUDE_WARN_BRN`
 
 - **Type:** float ($/min)
 - **Default:** `3.0`
-- **Read by:** `monitor.py:384` (`_env_float` → `WARN_BRN`)
+- **Read by:** `monitor.py` (`_env_float` → `WARN_BRN`)
 - **Effect:** burn-rate threshold above which the `BRN` segment switches
   to its alert color. The dashboard `BRN OVER TIME` axis is fixed at
   `0–10 $/min` regardless of this value (axis is set by `BRN_MAX`, not
@@ -93,7 +93,7 @@ have a documented diagnostic anchor.
 
 - **Type:** string
 - **Default:** set by the terminal emulator
-- **Read by:** `monitor.py:2529`
+- **Read by:** `monitor.py`
 - **Effect:** if `TERM=dumb`, `monitor.py` aborts with an explanatory
   message instead of trying to drive an interactive TUI on a non-capable
   terminal (CI logs, redirected output, etc.).
@@ -102,7 +102,7 @@ have a documented diagnostic anchor.
 
 - **Type:** int
 - **Default:** unset → `os.get_terminal_size()` fallback
-- **Read by:** `statusline.py:53` (`_get_terminal_width`)
+- **Read by:** `statusline.py` (`_get_terminal_width`)
 - **Effect:** explicit terminal-width override for the one-line
   statusline. Useful when the parent process (Claude Code) reports a
   width that differs from what the user sees, or for fixed-width tests.
@@ -116,7 +116,7 @@ have a documented diagnostic anchor.
 - **Effect:** root for `$TMPDIR/claude-aio-monitor/` — the IPC directory
   that holds session snapshots, JSONL history, the singleton lock, the
   crash log, and the rotated crash log. Whitelisted in `shared.run_git`'s
-  env scrub (`shared.py:307`).
+  env scrub (`shared.py`).
 
 ### `HOME` / `USERPROFILE`
 
@@ -165,7 +165,7 @@ are not part of the user-facing contract and may change without notice.
 
 ### `_TEST_ENV_FLOAT` / `_TEST_ENV_FLOAT_BAD`
 
-- **Read by:** `tests/test_monitor.py:758, 771` — `_env_float` parser
+- **Read by:** `tests/test_monitor.py` — `_env_float` parser
   smoke tests.
 - **Lifecycle:** set + unset within a single `setUp`/`tearDown` pair.
   Never leaks across test boundaries.

--- a/docs/FILE-IPC-CONTRACT.md
+++ b/docs/FILE-IPC-CONTRACT.md
@@ -1,8 +1,8 @@
-# FILE-IPC CONTRACT: cc-aio-mon v1.12.0
+# FILE-IPC CONTRACT: cc-aio-mon v1.12.4
 
 **Status**: Active  
-**Version**: 1.12.0 (`SCHEMA_VERSION` = 1)  
-**Last Updated**: 2026-05-22  
+**Version**: 1.12.4 (`SCHEMA_VERSION` = 1)  
+**Last Updated**: 2026-05-30  
 **Source Truth**: `shared.py`, `statusline.py`, `monitor.py`, `pulse.py`
 
 See also: [ARCHITECTURE.md](ARCHITECTURE.md) for module overview, [RELEASE.md](RELEASE.md) for release process.
@@ -38,13 +38,13 @@ Two long-running processes communicate solely via the filesystem—no sockets, p
 > - macOS: per-user `/var/folders/<hash>/T/`
 > - Windows: `%TEMP%` (e.g. `C:\Users\<user>\AppData\Local\Temp\`)
 
-**Constants** (source: `shared.py:50-51`):
+**Constants** (source: `shared.py`):
 - `DATA_DIR_NAME` = `"claude-aio-monitor"`
 - `DATA_DIR` = `pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME`
 
 ### Creator
 
-**Function**: `ensure_data_dir(d)` (`shared.py:279`)
+**Function**: `ensure_data_dir(d)` (`shared.py`)
 
 | Attribute | Value |
 |---|---|
@@ -54,7 +54,7 @@ Two long-running processes communicate solely via the filesystem—no sockets, p
 | Return value | `True` if created/verified; `False` if symlink/junction/unsafe |
 | Idempotent | Yes (mkdir exists_ok=True) |
 
-**Safety Check**: `is_safe_dir(p)` (`shared.py:261`)
+**Safety Check**: `is_safe_dir(p)` (`shared.py`)
 
 Rejects symlinks and reparse points (Windows junctions). Uses `lstat()` (TOCTOU-resistant):
 - Unix: `not S_ISDIR(st_mode) → False`
@@ -68,7 +68,7 @@ Callers must call `ensure_data_dir()` once at startup, then all file operations 
 
 ### Regex Pattern
 
-**Source**: `shared.py:34-36`
+**Source**: `shared.py`
 
 ```python
 _SID_RE = re.compile(
@@ -85,7 +85,7 @@ _SID_RE = re.compile(
 
 ### Reserved Session IDs
 
-**Source**: `shared.py:27`
+**Source**: `shared.py`
 
 ```python
 RESERVED_SIDS = frozenset({"rls", "stats", "pulse"})
@@ -123,7 +123,7 @@ Example: `$TMPDIR/claude-aio-monitor/default.json`
 
 ### Writing (statusline.py)
 
-**Function**: `write_shared_state(data: dict)` (`statusline.py:278-333`)
+**Function**: `write_shared_state(data: dict)` (`statusline.py`)
 
 1. Validate session ID via `_SID_RE`
 2. Ensure data directory (exit early if `not ensure_data_dir()`)
@@ -149,7 +149,7 @@ pathlib.Path(fd.name).replace(target)  # atomic on all platforms
 
 ### Reading (monitor.py)
 
-**Function**: `load_state(sid)` (`monitor.py:739-750`)
+**Function**: `load_state(sid)` (`monitor.py`)
 
 ```python
 def load_state(sid):
@@ -161,17 +161,23 @@ def load_state(sid):
     if raw is None:
         return None
     try:
-        return json.loads(raw.decode("utf-8"))
+        d = json.loads(raw.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError):
         return None
+    # Refuse a snapshot tagged newer than this build understands (schema gate).
+    if (isinstance(d, dict) and isinstance(d.get("_schema_version"), int)
+            and d["_schema_version"] > SCHEMA_VERSION):
+        return None
+    return d
 ```
 
 - Validates `sid` and directory safety
 - Bounded read: `safe_read()` caps at `MAX_FILE_SIZE` (1 MB)
 - Returns parsed dict or `None` on error
 - **No exception raised** on malformed JSON (returns `None`)
+- **Schema gate**: a `_schema_version` newer than `shared.SCHEMA_VERSION` degrades to `None`
 
-**Poll Cadence**: Main loop (`monitor.py:2618`) polls `load_state()` every 500 ms per session.
+**Poll Cadence**: The main loop polls `load_state()` for each active session on every data-load interval.
 
 ### JSON Schema
 
@@ -202,14 +208,15 @@ def load_state(sid):
 
 ### Schema Version
 
-**Current Value**: 1 (`shared.py:62`)
+**Current Value**: 1 (`shared.SCHEMA_VERSION`)
 
 **Semantics**:
 - Added to snapshot at write time by statusline: `{..., "_schema_version": 1}`
-- Monitor reads via `dict.get("_schema_version")` → `None` if absent (pre-v1.10 snapshots)
-- Bumped when JSON shape changes incompatibly (e.g., rename field, change nesting)
-- **No version check in monitor yet** — all reads are defensive (dict.get with defaults)
-- Future `read_session_snapshot()` function could gate on this value
+- `monitor.load_state()` **gates** on it: a snapshot tagged NEWER than the running
+  build degrades to `None` (treated as unreadable) rather than risk a misread of
+  an incompatible shape
+- Missing or older tags default to `0` (pre-v1.10 snapshots) and stay readable
+- Bumped when the JSON shape changes incompatibly (e.g., rename field, change nesting)
 
 ### File Size & Disk Full
 
@@ -236,7 +243,7 @@ Example: `$TMPDIR/claude-aio-monitor/default.jsonl`
 
 ### Writing (statusline.py)
 
-**Function**: `write_shared_state()` (`statusline.py:324-333`; the surrounding alignment guard at `statusline.py:320-322` aborts the append if the snapshot write failed)
+**Function**: `write_shared_state()` (`statusline.py`; the surrounding alignment guard at `statusline.py` aborts the append if the snapshot write failed)
 
 After successful snapshot write:
 
@@ -245,7 +252,7 @@ After successful snapshot write:
 3. No fsync (relies on OS buffering + rename for atomicity)
 4. Check file size after write; if `> MAX_FILE_SIZE`, call `_trim_history()`
 
-**Trim Policy** (`statusline.py:336-361`):
+**Trim Policy** (`statusline.py`):
 
 - **Trigger**: File size > 1 MB (`MAX_FILE_SIZE`)
 - **Trim target**: Last 1000 lines (`HISTORY_TRIM_TO`)
@@ -255,7 +262,7 @@ After successful snapshot write:
 
 ### Reading (shared.py + monitor.py)
 
-**Function**: `load_history(sid, n=HISTORY_RATE_SAMPLES, data_dir=None)` (`shared.py:142`)
+**Function**: `load_history(sid, n=HISTORY_RATE_SAMPLES, data_dir=None)` (`shared.py`)
 
 Single source of truth for both statusline and monitor. `HISTORY_RATE_SAMPLES`
 defaults to 120 — at ~1 statusline event/min this is a ~2-hour rolling window.
@@ -343,7 +350,7 @@ Example: `$TMPDIR/claude-aio-monitor/pulse.jsonl`
 
 ### Writing (pulse.py)
 
-**Function**: `_append_log(snap)` (`pulse.py:490-513`)
+**Function**: `_append_log(snap)` (`pulse.py`)
 
 Called by `_refresh_once()` after each fetch + ping cycle.
 
@@ -362,7 +369,7 @@ rec = {
 line = json.dumps(rec) + "\n"
 ```
 
-**Append Pattern** (`pulse.py:509-510`):
+**Append Pattern** (`pulse.py`):
 ```python
 with open(LOG_PATH, "a", encoding="utf-8") as f:
     f.write(line)
@@ -372,12 +379,12 @@ No temp file; appends directly. Rotation guard called after every `ROTATE_CHECK_
 
 ### Retention Policy
 
-**Startup Cleanup** (`pulse.py:436-465`):
+**Startup Cleanup** (`pulse.py`):
 - Drops entries older than `LOG_AGE_CUTOFF = 24 hours`
 - Hard cap: max `LOG_STARTUP_CAP = 2000` records kept
 - Called once in `start_pulse_worker()` before launching worker thread
 
-**Runtime Rotation** (`pulse.py:468-487`):
+**Runtime Rotation** (`pulse.py`):
 - Every `ROTATE_CHECK_EVERY = 100` appends, check file size
 - If `file.stat().st_size > LOG_MAX_BYTES (1 MB)`: trim to last `LOG_TRIM_TARGET = 500` lines
 - Bounded read (2 MB cap) protects against TOCTOU growth
@@ -417,7 +424,7 @@ Example: `$TMPDIR/claude-aio-monitor/monitor-crash.log`
 
 ### Writing (monitor.py)
 
-**Function**: `_install_crash_logger()` (`monitor.py:2323-2350`)
+**Function**: `_install_crash_logger()` (`monitor.py`)
 
 Installed once at startup via `sys.excepthook = excepthook`. Captures any uncaught exception. (Snippet below is abbreviated for readability — the real implementation also writes platform / Python version / encoding metadata before the traceback.)
 
@@ -496,7 +503,7 @@ Lock file mechanism introduced to prevent multiple monitors from corrupting the 
 
 ### Acquisition
 
-**Function**: `acquire_singleton_lock(lock_path)` (`shared.py:441`)
+**Function**: `acquire_singleton_lock(lock_path)` (`shared.py`)
 
 ```python
 def acquire_singleton_lock(lock_path):
@@ -554,7 +561,7 @@ def acquire_singleton_lock(lock_path):
 
 ### Usage in monitor.py
 
-**Source**: `monitor.py:2392-2400`
+**Source**: `monitor.py`
 
 ```python
 if ensure_data_dir(DATA_DIR):
@@ -646,7 +653,7 @@ Multiple `--list` invocations can run concurrently with monitor or each other.
 
 ### Current State
 
-- **`SCHEMA_VERSION`** = 1 (`shared.py:62`)
+- **`SCHEMA_VERSION`** = 1 (`shared.py`)
 - **Version in file**: `_schema_version: 1` added to every snapshot & history entry by statusline.py
 
 ### Backward Compatibility
@@ -768,14 +775,14 @@ All IPC is best-effort. No exceptions are raised to the user—errors are logged
 - [Error Handling](#error-cases--silent-failures)
 
 **Functions** (with source)
-- `ensure_data_dir()` – `shared.py:279`
-- `is_safe_dir()` – `shared.py:241-256`
-- `safe_read()` – `shared.py:156-173`
-- `load_history()` – `shared.py:122-153`
-- `load_state()` – `monitor.py:739-750`
-- `write_shared_state()` – `statusline.py:278-333`
-- `acquire_singleton_lock()` – `shared.py:397-445`
-- `rotate_crash_log()` – `shared.py:376-394`
+- `ensure_data_dir()` – `shared.py`
+- `is_safe_dir()` – `shared.py`
+- `safe_read()` – `shared.py`
+- `load_history()` – `shared.py`
+- `load_state()` – `monitor.py`
+- `write_shared_state()` – `statusline.py`
+- `acquire_singleton_lock()` – `shared.py`
+- `rotate_crash_log()` – `shared.py`
 
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,10 +16,12 @@ See also: [ARCHITECTURE.md](ARCHITECTURE.md) for module overview, [FILE-IPC-CONT
 - Changing the public Python import API (functions/classes that external code
   could import from `shared.py`).
 - Removing CLI flags from `update.py` or `statusline.py`.
-- Bumping `SCHEMA_VERSION` in `shared.py` in a way that older monitor versions
-  cannot silently ignore. (The current `dict.get()` pattern in snapshot readers
-  means the tag is forward-compatible and advisory only — a MAJOR bump is not
-  needed unless you remove existing fields or change their types.)
+- Bumping `SCHEMA_VERSION` in `shared.py`. `monitor.load_state()` refuses a
+  snapshot tagged newer than the running build (it degrades to `None` = "no
+  data" until that monitor self-updates), so a bump causes a transient blind
+  spot for already-running older monitors rather than a crash or hard break.
+  Treat a bump as MINOR when existing fields stay readable; reserve MAJOR for
+  removing or retyping existing fields.
 
 **MINOR** — new features, new env-var knobs, new modals, new segments. Recent
 examples: v1.12.0 (singleton lock, crash-log rotation, schema version tag,
@@ -42,6 +44,11 @@ from wrong file, null-payload dashboard crash).
 
 Work through these in order before creating any tag.
 
+> Tip: `scripts/release.sh X.Y.Z` runs the mechanical gate of this checklist
+> (VERSION bump match, CHANGELOG entry, compile check, full test suite) and then
+> prints the PR push sequence from Section 5. It performs no irreversible action
+> — it never pushes, tags, or merges.
+
 - [ ] **Branch is `main`, working tree is clean.**
   ```
   git status --porcelain -uno
@@ -55,25 +62,25 @@ Work through these in order before creating any tag.
   python3 tests.py     # macOS / Linux
   ```
   `tests.py` is a thin wrapper that runs `unittest discover tests/`
-  (`tests.py:main()`). Current baseline: **608 passing** (v1.12.3). The new
+  (`tests.py:main()`). Current baseline: **617 passing** (v1.12.5). The new
   release's count must be >= this number unless tests were intentionally
   removed (document the removal in CHANGELOG).
 
 - [ ] **CHANGELOG entry drafted** (see Section 3 for exact format).
   Write the entry for the new version at the top of `CHANGELOG.md`, above the
-  current `## v1.12.3` block. Do not push yet.
+  current `## v1.12.4` block. Do not push yet.
 
 - [ ] **VERSION constant bumped in `shared.py` only.**
-  The constant lives at `shared.py:55`:
+  The constant lives at `shared.py`:
   ```python
-  VERSION = "1.12.3"
+  VERSION = "1.12.4"
   ```
   Change this string to the new version. Do not touch `monitor.py`,
   `pulse.py`, or `update.py` for the version — all three import from
   `shared.py` (`from shared import VERSION` or similar). `update.py`'s
   `get_local_version()` and `get_remote_version()` both regex-scan
   `shared.py` via `VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']',
-  re.MULTILINE)` (`shared.py:52`). If you put the version anywhere else,
+  re.MULTILINE)` (`shared.py`). If you put the version anywhere else,
   the release-check worker silently reports `error`.
 
 - [ ] **Re-run tests after the VERSION and CHANGELOG edits.**
@@ -164,7 +171,7 @@ headers, bullet list under each, blank line, trailing test count line.
   them via `unittest discover`.
 
 - [ ] **Syntax check covers all five modules.**
-  `shared.PY_FILES` (`shared.py:107`) lists every file the post-pull syntax
+  `shared.PY_FILES` (`shared.py`) lists every file the post-pull syntax
   check verifies:
   ```python
   PY_FILES = ("monitor.py", "statusline.py", "shared.py", "pulse.py", "update.py")
@@ -197,27 +204,39 @@ headers, bullet list under each, blank line, trailing test count line.
 Order matters. The self-update mechanism is commit-driven, not tag-driven
 (see Section 6). Follow this sequence exactly:
 
+`main` is protected (`enforce_admins` is on), so the version bump lands via a
+PR — direct `git push origin main` is rejected even for the maintainer. The tag
+is still applied to the merge commit *after* it is on `main`:
+
 ```bash
-# 1. Stage and commit (CHANGELOG + shared.py version bump only)
+# 1. Create a release branch and commit (CHANGELOG + shared.py version bump only)
+git switch -c release/vX.Y.Z
 git add CHANGELOG.md shared.py
 git commit -m "chore(release): bump to vX.Y.Z"
 
-# 2. Push the commit to main FIRST
-git push origin main
+# 2. Push the branch and open a PR against main
+git push origin release/vX.Y.Z
+gh pr create --fill --base main
 
-# 3. Tag the commit (after push, not before)
+# 3. Once CI is green (incl. release-smoke), squash-merge — this lands the
+#    version bump on main HEAD, which is what self-update reads
+gh pr merge --squash --delete-branch
+
+# 4. Sync local main to the merge commit, THEN tag it (after it is on main)
+git switch main && git pull --ff-only origin main
 git tag vX.Y.Z
 
-# 4. Push the tag separately
+# 5. Push the tag separately
 git push origin vX.Y.Z
 ```
 
 **Why this order:** `update.py:get_remote_version()` reads
 `origin/main:shared.py` via `git show` — it compares against the remote
 branch HEAD, not against tags. Users who run `py update.py` (no `--apply`)
-immediately after you push the commit will see the new version as available.
-If you tag before pushing the commit, the tag exists but the release-check
-worker cannot see the version bump yet (it only reads `origin/main`).
+after the PR merges will see the new version as available. The tag must point
+at a commit that is already on `main`; tagging before the merge lands would
+leave the release-check worker blind to the version bump (it only reads
+`origin/main`).
 
 **Signed tags** (`git tag -s vX.Y.Z`) are optional but encouraged for
 releases that touch security-sensitive code paths. The tag message should
@@ -238,10 +257,10 @@ following are true after your push:
 
 | What the code checks | Where it reads | Failure mode if wrong |
 |---|---|---|
-| Remote VERSION string | `git show origin/main:shared.py` → `VERSION_RE` (`shared.py:52`) | Reports `error` in release indicator; `RuntimeError: VERSION constant not found in remote shared.py` on `--apply` |
-| Remote CHANGELOG entry | `git show origin/main:CHANGELOG.md` → `extract_changelog_entry(text, version, max_lines=None)` (`shared.py:320`) | Update modal shows no changelog preview; not fatal |
+| Remote VERSION string | `git show origin/main:shared.py` → `VERSION_RE` (`shared.py`) | Reports `error` in release indicator; `RuntimeError: VERSION constant not found in remote shared.py` on `--apply` |
+| Remote CHANGELOG entry | `git show origin/main:CHANGELOG.md` → `extract_changelog_entry(text, version, max_lines=None)` (`shared.py`) | Update modal shows no changelog preview; not fatal |
 | `git pull --ff-only` succeeds | Requires `main` is linear (no force-push, no rebase of published history) | `git pull` exits non-zero; user is left on old version with the rollback tag as recovery point |
-| Post-pull syntax check passes | `shared.check_syntax_after_pull(repo_root)` iterates `PY_FILES` (`shared.py:107`) | Warns user `Syntax errors in: <file>` and shows rollback hint |
+| Post-pull syntax check passes | `shared.check_syntax_after_pull(repo_root)` iterates `PY_FILES` (`shared.py`) | Warns user `Syntax errors in: <file>` and shows rollback hint |
 
 **Critical constraint:** `git pull --ff-only` requires that `origin/main` is a
 fast-forward ancestor of the user's local `main`. If you ever rebase or
@@ -255,13 +274,32 @@ history on `main`.
 a new `.py` module to the project, add it to `PY_FILES` in `shared.py` so
 post-pull checks catch syntax errors in it.
 
+**Blast radius — there is no staged rollout (by design).** Self-update is
+trunk-based: every commit that lands on `main` reaches *all* auto-updating
+installs at once (the in-monitor release check polls `origin/main` hourly).
+There is no `next`/`beta` channel or canary cohort — a single maintainer does
+not have the operational capacity to soak releases, and adding channels would
+complicate the update path for a marginal cohort. The accepted mitigations are:
+
+- **Pre-merge gate:** `release-smoke.yml` runs the *real* `update.py --apply`
+  path from the previous tag on every push to `main`, so a broken self-update
+  is caught in CI before users pull it.
+- **Per-user rollback:** `update.py --apply` writes a `pre-update-*` tag before
+  pulling (see Section 7), so any user can revert in one command.
+- **Fast-forward-only safety:** `git pull --ff-only` refuses to apply a
+  non-linear update rather than corrupting a working tree.
+
+If the project ever grows beyond a single maintainer or adds higher-risk
+self-modifying paths, revisit this with a `next`-branch soak step before the
+`main` merge.
+
 ---
 
 ## 7. Rollback — if a release breaks something after tagging
 
 `update.py --apply` automatically creates a local rollback tag on the user's
-machine (`pre-update-YYYYMMDD-HHMMSS`, `update.py:186-194`) before running
-`git pull`. Users can recover with:
+machine (`pre-update-YYYYMMDD-HHMMSS`, in `update.py:apply_update()`) before
+running `git pull`. Users can recover with:
 
 ```bash
 git reset --hard pre-update-20260522-143000
@@ -271,9 +309,9 @@ On the maintainer side, **do not delete the broken tag**. Users who already
 pulled may have it in their local repo. Deleting it breaks their reference.
 Instead:
 
-1. Fix the issue in a new commit on `main`.
-2. Push the fix commit.
-3. Create a new patch tag: `git tag vX.Y.Z+1` (e.g. `v1.12.3` if `v1.12.2`
+1. Fix the issue in a new commit on a branch.
+2. Merge it to `main` via PR (direct push is blocked — see Section 5).
+3. Create a new patch tag: `git tag vX.Y.Z+1` (e.g. `v1.12.5` if `v1.12.4`
    was broken), push it.
 4. Update CHANGELOG with a brief PATCH entry describing the regression and fix.
 

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -114,6 +114,7 @@ Restart Claude Code after updating. See [README — Updating](../README.md#updat
 
 **Diacritics show as `Ĺĺ` / `ĂĄ` / `Ăľ` mojibake**
 - `monitor.py` already switches the console output code page to UTF-8 (CP 65001) on startup and restores it on exit. If you still see mojibake, you are likely either (a) on a Windows version that does not honour `SetConsoleOutputCP` from Python (rare), or (b) viewing the screen of a `monitor.py` instance started **before** v1.12.1 — quit (`q`) and relaunch.
+- Diacritics in **session names / titles** are handled on the input side too: `statusline.py` reads Claude Code's stdin JSON as UTF-8 bytes rather than the locale code page, so accented `session_name` / auto-titles survive even when Claude Code's subprocess environment lacks `PYTHONUTF8=1` (fixed in v1.12.1). If an older session still shows a garbled title, switch session (`s`) to re-read a fresh snapshot.
 - Manual fallback: `chcp 65001` before launching, or enable the system-wide UTF-8 locale (Settings → Time & Language → Language & region → Administrative language settings → "Beta: Use Unicode UTF-8 for worldwide language support").
 
 **Raw escape codes visible**

--- a/monitor.py
+++ b/monitor.py
@@ -37,7 +37,7 @@ from shared import (calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_dur
                     SECONDS_1H, SECONDS_5H, SECONDS_1D, SECONDS_7D,
                     HISTORY_RATE_SAMPLES,
                     WARN_PCT, CRIT_PCT,
-                    DATA_DIR, VERSION_RE, VERSION,
+                    DATA_DIR, VERSION_RE, VERSION, SCHEMA_VERSION,
                     PY_FILES,  # noqa: F401 — pinned by TestPyFilesSingleSourceOfTruth (SSoT regression guard)
                     RESERVED_SIDS, strip_context_suffix, compact_context_suffix,
                     extract_changelog_entry,
@@ -676,7 +676,7 @@ def _rls_maybe_check():
 
     Lock ownership: acquired here, released by _rls_check_worker's `finally`
     OR here if the Thread spawn itself fails. Worker must not return
-    without releasing. Keep in sync with _rls_check_worker:524.
+    without releasing. Keep in sync with `_rls_check_worker` finally block.
     """
     if os.environ.get("CC_AIO_MON_NO_UPDATE_CHECK") == "1":
         return
@@ -886,9 +886,19 @@ def load_state(sid):
     if raw is None:
         return None
     try:
-        return json.loads(raw.decode("utf-8"))
+        d = json.loads(raw.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError):
         return None
+    # IPC schema gate (M-cross-2): statusline tags every snapshot with
+    # _schema_version. A snapshot written by a NEWER build than this one —
+    # possible briefly mid self-update before the monitor restarts — may have
+    # an incompatible shape, so treat it as unreadable (degrade to None) rather
+    # than risk misreading fields. A missing/older tag (pre-versioning snapshots
+    # left on disk after a git pull) defaults to 0 and stays readable.
+    if (isinstance(d, dict) and isinstance(d.get("_schema_version"), int)
+            and d["_schema_version"] > SCHEMA_VERSION):
+        return None
+    return d
 
 
 # Thin wrapper — shared.load_history is the single source of truth (v1.10.5+).
@@ -1921,6 +1931,11 @@ def render_menu(cols, rows):
 # ---------------------------------------------------------------------------
 _update_result = None  # None=not run, str=output message
 _update_lock = threading.Lock()
+# Handle to the in-flight self-update worker (set by _apply_update_action).
+# Read by the main loop's `q` handler to refuse quitting mid git-pull, which
+# would kill the daemon before its post-pull syntax check runs (M-cross-1).
+# Written and read only on the main thread; is_alive() is thread-safe.
+_update_thread = None
 
 # Update modal git-helper cache — 30s TTL, invalidated on remote_ver change.
 # Eliminates per-tick (50ms) synchronous git subprocess spam from render path
@@ -2076,9 +2091,12 @@ def _apply_update_worker():
 
 def _apply_update_action():
     """Spawn background thread for update. Non-blocking."""
+    global _update_thread
     _set_update_result("Updating...")
-    t = threading.Thread(target=_apply_update_worker, daemon=True)
-    t.start()
+    _update_thread = threading.Thread(
+        target=_apply_update_worker, name="update-apply", daemon=True
+    )
+    _update_thread.start()
 
 
 def render_update_modal(cols, rows):
@@ -2698,7 +2716,15 @@ def main():
             # Always poll keyboard
             k = poll_key()
             if k == "q":
-                break
+                if _update_thread is not None and _update_thread.is_alive():
+                    # Self-update worker is mid git-pull / post-pull syntax
+                    # check: refuse to quit so we don't kill the daemon and
+                    # leave the repo fast-forwarded but never integrity-checked
+                    # (M-cross-1). Falls through to a normal render tick; quit
+                    # works again once the worker finishes (a few seconds).
+                    pass
+                else:
+                    break
             # ── Modal-specific handlers first (priority) ──
             elif show_update and k == "a" and _get_update_result() is None:
                 _apply_update_action()

--- a/pulse.py
+++ b/pulse.py
@@ -28,19 +28,18 @@ Snapshot schema (keys may be None during warm-up or on errors):
 """
 
 import json
-import os
-import pathlib
 import re
 import socket
 import statistics
-import tempfile
 import threading
 import time
 import urllib.error
 import urllib.request
 from collections import deque
+from typing import List, Optional, TypedDict
 
-from shared import DATA_DIR, MAX_FILE_SIZE, SECONDS_1D, ensure_data_dir, safe_read, VERSION
+from shared import (DATA_DIR, MAX_FILE_SIZE, SECONDS_1D, atomic_write_text,
+                    ensure_data_dir, safe_read, VERSION)
 
 # ---------------------------------------------------------------------------
 # Config
@@ -104,7 +103,28 @@ _W_LATENCY = 0.20
 # ---------------------------------------------------------------------------
 # Shared state
 # ---------------------------------------------------------------------------
-_snapshot = {
+class PulseSnapshot(TypedDict):
+    """Typed view of the pulse snapshot — the public IPC contract returned by
+    get_pulse_snapshot() and consumed by monitor.render_pulse_modal. Codifies
+    the field list documented in the module docstring; the runtime value stays
+    a plain dict (TypedDict adds no runtime overhead or validation)."""
+    t: float
+    wall_t: float
+    score: Optional[int]
+    raw_score: Optional[int]
+    verdict: str
+    level: str
+    reason: str
+    indicator: Optional[str]
+    incidents: List[dict]
+    components: List[dict]
+    latency_ms: Optional[float]
+    latency_p50_ms: Optional[int]
+    latency_p95_ms: Optional[int]
+    error: Optional[str]
+
+
+_snapshot: PulseSnapshot = {
     "t": 0.0,
     "wall_t": 0.0,
     "score": None,
@@ -146,7 +166,7 @@ def _latency_score(latency_ms):
     return 10
 
 
-def indicator_label(indicator):
+def indicator_label(indicator: Optional[str]) -> str:
     """Map Statuspage indicator value to human-readable label. Public API
     so monitor.render_pulse_modal can format it without reaching into a
     private symbol."""
@@ -213,7 +233,7 @@ def _reset_history():
         _latency_history.clear()
 
 
-def compute_score(raw):
+def compute_score(raw: dict) -> dict:
     """Pure scoring fn. Input: raw fetch dict. Output: snapshot dict (partial).
 
     raw = {
@@ -336,15 +356,6 @@ def _ping_api():
     return (time.monotonic() - start) * 1000.0
 
 
-# Regex patterns to detect affected model(s) in incident titles.
-# Word-boundary match to avoid false positives (e.g. "opus" in unrelated words).
-_MODEL_PATTERNS = {
-    "opus":   re.compile(r"\bopus\b",   re.IGNORECASE),
-    "sonnet": re.compile(r"\bsonnet\b", re.IGNORECASE),
-    "haiku":  re.compile(r"\bhaiku\b",  re.IGNORECASE),
-}
-
-
 def _tag_models_from_incident(inc):
     """Return sorted model tags for an incident.
 
@@ -420,25 +431,7 @@ def _atomic_replace_log(lines):
     """Atomically rewrite LOG_PATH with `lines` (iterable of strings with \\n)."""
     if not ensure_data_dir(DATA_DIR):
         return
-    fd = None
-    try:
-        fd = tempfile.NamedTemporaryFile(
-            dir=str(DATA_DIR), suffix=".tmp", delete=False,
-            mode="w", encoding="utf-8",
-        )
-        fd.writelines(lines)
-        fd.close()
-        pathlib.Path(fd.name).replace(LOG_PATH)
-    except OSError:
-        if fd is not None:
-            try:
-                fd.close()
-            except OSError:
-                pass
-            try:
-                os.unlink(fd.name)
-            except OSError:
-                pass
+    atomic_write_text(LOG_PATH, lines, writelines=True)
 
 
 def cleanup_log_startup():
@@ -598,25 +591,45 @@ def _refresh_once():
     _append_log(new_snap)
 
 
+def _crash_snapshot() -> PulseSnapshot:
+    """Snapshot payload for the worker last-resort crash handler.
+
+    Resets every data-bearing field (indicator/incidents/components/latency/
+    scores) to its neutral init value so a 'PULSE ERROR' state can never
+    surface stale data captured before the crash — otherwise a crash right
+    after a healthy fetch would render "PULSE ERROR" alongside the previous
+    "all green" incidents/components, masking a real outage (M-cross-3).
+    Aligned with the initial `_snapshot` literal above.
+    """
+    return {
+        "t": time.monotonic(),
+        "wall_t": time.time(),
+        "score": None,
+        "raw_score": None,
+        "verdict": "PULSE ERROR",
+        "level": "error",
+        "reason": "worker crashed",
+        "indicator": None,
+        "incidents": [],
+        "components": [],
+        "latency_ms": None,
+        "latency_p50_ms": None,
+        "latency_p95_ms": None,
+        "error": "worker crash",
+    }
+
+
 def _worker_loop():
     while True:
         try:
             _refresh_once()
         except Exception:  # last-resort guard — daemon must not die
             with _snapshot_lock:
-                _snapshot.update({
-                    "t": time.monotonic(),
-                    "wall_t": time.time(),
-                    "score": None,
-                    "verdict": "PULSE ERROR",
-                    "level": "error",
-                    "reason": "worker crashed",
-                    "error": "worker crash",
-                })
+                _snapshot.update(_crash_snapshot())
         time.sleep(FETCH_INTERVAL)
 
 
-def start_pulse_worker():
+def start_pulse_worker() -> None:
     """Start the background fetcher. Idempotent.
 
     Runs startup cleanup on pulse.jsonl before launching the worker thread.
@@ -641,7 +654,7 @@ def start_pulse_worker():
         raise
 
 
-def get_pulse_snapshot():
+def get_pulse_snapshot() -> PulseSnapshot:
     """Return a shallow copy of the latest snapshot."""
     with _snapshot_lock:
         return dict(_snapshot)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# release.sh — release pre-flight for cc-aio-mon.
+#
+# Validates that the working tree is ready to cut version X.Y.Z and runs the
+# full gate (version bump check, CHANGELOG entry, compile check, test suite),
+# then prints the exact PR-based push sequence from docs/RELEASE.md Section 5.
+#
+# It deliberately does NOT push, tag, or merge: `main` is branch-protected
+# (enforce_admins), so a release lands via PR. This script eliminates the
+# slip risk of a manual checklist (forgotten VERSION bump, missing CHANGELOG
+# entry, failing tests) without performing any irreversible action.
+#
+# Usage:  scripts/release.sh X.Y.Z
+#
+# Maintainer tool (Linux/macOS bash). Not shipped to end users, not part of the
+# five runtime modules in shared.PY_FILES.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+ok()   { printf '[OK]  %s\n' "$1"; }
+errln(){ printf '[!!]  %s\n' "$1" >&2; }
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    errln "Usage: scripts/release.sh X.Y.Z"
+    exit 2
+fi
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    errln "Version must be X.Y.Z (got: $VERSION)"
+    exit 2
+fi
+
+PY="$(command -v python3 || command -v py || true)"
+if [ -z "$PY" ]; then
+    errln "python3 / py not found on PATH"
+    exit 1
+fi
+
+# Escape dots for use in an ERE.
+VERSION_RE="${VERSION//./\\.}"
+fail=0
+
+# 1) shared.VERSION must already be bumped to match the requested release.
+#    Tolerate an import failure (e.g. a syntax error in shared.py) under `set -e`
+#    so the fail-accumulator keeps going and the compile gate (step 3) reports
+#    the precise error location instead of a bare traceback aborting the script.
+SHARED_VER="$("$PY" -c "import shared; print(shared.VERSION)" 2>/dev/null || true)"
+if [ "$SHARED_VER" = "$VERSION" ]; then
+    ok "shared.VERSION == $VERSION"
+elif [ -z "$SHARED_VER" ]; then
+    errln "could not read shared.VERSION (shared.py import failed — see compile check below)"
+    fail=1
+else
+    errln "shared.VERSION is $SHARED_VER, expected $VERSION — bump shared.py first"
+    fail=1
+fi
+
+# 2) CHANGELOG must carry a matching entry (## vX.Y.Z ...).
+if grep -Eq "^## v${VERSION_RE}([^0-9]|$)" CHANGELOG.md; then
+    ok "CHANGELOG.md has a '## v$VERSION' entry"
+else
+    errln "CHANGELOG.md is missing a '## v$VERSION' entry"
+    fail=1
+fi
+
+# 3) Compile gate — same file list as CI and the post-update syntax check.
+if "$PY" -c "import py_compile, shared; [py_compile.compile(f, doraise=True) for f in shared.PY_FILES]"; then
+    ok "Syntax check passed (PY_FILES)"
+else
+    errln "Syntax check failed"
+    fail=1
+fi
+
+# 4) Full test suite must pass.
+if "$PY" tests.py >/dev/null 2>&1; then
+    ok "Test suite passed"
+else
+    errln "Test suite failed — run '$PY tests.py' to see details"
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    errln "Pre-flight failed — fix the above before releasing."
+    exit 1
+fi
+
+cat <<EOF
+
+All pre-flight checks passed for v$VERSION.
+
+main is branch-protected — land the release via PR (docs/RELEASE.md Section 5):
+
+  git switch -c release/v$VERSION
+  git add CHANGELOG.md shared.py
+  git commit -m "chore(release): bump to v$VERSION"
+  git push origin release/v$VERSION
+  gh pr create --fill --base main
+  gh pr merge --squash --delete-branch
+  git switch main && git pull --ff-only origin main
+  git tag v$VERSION && git push origin v$VERSION
+
+Then complete the Section 8 post-release checks.
+EOF

--- a/shared.py
+++ b/shared.py
@@ -52,13 +52,14 @@ DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.12.4"
+VERSION = "1.12.5"
 
 # File-IPC contract version. Statusline writes this field on every snapshot
-# and history entry; bumped when the JSON shape changes incompatibly. Monitor
-# currently reads snapshots via dict.get(), so an unknown _schema_version is
-# silently ignored — making the tag future-proof but advisory today. A future
-# monitor read site (e.g. read_session_snapshot) can gate on this value.
+# and history entry; bumped when the JSON shape changes incompatibly. Monitor's
+# load_state() gates on it: a snapshot tagged NEWER than this constant is
+# treated as unreadable (degrades to None) rather than risk misreading an
+# incompatible shape. Missing/older tags default to 0 and stay readable, so
+# pre-versioning snapshots left on disk after a git pull are tolerated.
 SCHEMA_VERSION = 1
 
 # Default sample window for load_history(). At ~1 statusline event/min this
@@ -243,8 +244,8 @@ def f_cd(epoch):
     diff = int(epoch - time.time())
     if diff <= 0:
         return "now"
-    d, rem = divmod(diff, 86400)
-    h, rem = divmod(rem, 3600)
+    d, rem = divmod(diff, SECONDS_1D)
+    h, rem = divmod(rem, SECONDS_1H)
     m = rem // 60
     if d > 0:
         return f"{d}d {h:02d}h"
@@ -436,6 +437,50 @@ def rotate_crash_log(path: pathlib.Path, max_bytes: int = MAX_FILE_SIZE, always:
         path.replace(backup)
     except OSError:
         pass
+
+
+def atomic_write_text(target, data, *, writelines: bool = False) -> bool:
+    """Atomically write UTF-8 text to ``target`` via an unpredictable temp file
+    in the same directory, then ``os.replace()`` onto the target (a same-
+    filesystem rename — atomic on POSIX and Windows). Returns ``True`` on
+    success, ``False`` on any OSError.
+
+    ``data`` is a single string by default; pass ``writelines=True`` to write an
+    iterable of strings (each must already carry its own newline). On failure
+    the temp file is closed and unlinked so a botched write never leaks a
+    ``.tmp`` file. Best-effort by design — callers that must keep two files
+    aligned (e.g. snapshot vs history) branch on the bool return.
+
+    ``target.parent`` must already exist and be writable; callers run
+    ``ensure_data_dir`` first. Consolidates the previously-duplicated temp-file
+    scaffold in statusline.write_shared_state / _trim_history and
+    pulse._atomic_replace_log (M-2).
+    """
+    target = pathlib.Path(target)
+    fd = None
+    try:
+        fd = tempfile.NamedTemporaryFile(
+            dir=str(target.parent), suffix=".tmp", delete=False,
+            mode="w", encoding="utf-8",
+        )
+        if writelines:
+            fd.writelines(data)
+        else:
+            fd.write(data)
+        fd.close()
+        pathlib.Path(fd.name).replace(target)
+        return True
+    except OSError:
+        if fd is not None:
+            try:
+                fd.close()
+            except OSError:
+                pass
+            try:
+                os.unlink(fd.name)
+            except OSError:
+                pass
+        return False
 
 
 def acquire_singleton_lock(lock_path) -> Optional[IO]:

--- a/statusline.py
+++ b/statusline.py
@@ -18,10 +18,10 @@ import pathlib
 import signal
 import struct
 import sys
-import tempfile
 import time
 
-from shared import (calc_rates as _calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_cd,
+from shared import (calc_rates as _calc_rates, _num, _sanitize, safe_read, atomic_write_text,
+                    f_tok, f_cost, f_cd,
                     ensure_data_dir, ensure_utf8_stdout, load_history as _shared_load_history,
                     _SID_RE, _ANSI_RE, MAX_FILE_SIZE, HISTORY_READ_MAX, HISTORY_RATE_SAMPLES,
                     DATA_DIR, RESERVED_SIDS, SCHEMA_VERSION,
@@ -293,7 +293,8 @@ def write_shared_state(data: dict):
     base = DATA_DIR
 
     # Serialize once — same rules for snapshot and history (avoid TypeError mid-write).
-    # _schema_version tags the file-IPC contract: monitor reads it; older snapshots
+    # _schema_version tags the file-IPC contract: monitor.load_state() gates on
+    # it (newer-than-known snapshots degrade to None); older/untagged snapshots
     # already on disk after a `git pull` are tolerated (treated as v0 = pre-tag).
     try:
         snapshot = json.dumps({**data, "_schema_version": SCHEMA_VERSION})
@@ -301,28 +302,9 @@ def write_shared_state(data: dict):
     except (TypeError, ValueError):
         return
 
-    # Atomic write of current state via unpredictable temp file
+    # Atomic write of current state via unpredictable temp file (shared helper)
     target = base / f"{sid}.json"
-    snapshot_ok = False
-    fd = None
-    try:
-        fd = tempfile.NamedTemporaryFile(
-            dir=base, suffix=".tmp", delete=False, mode="w", encoding="utf-8"
-        )
-        fd.write(snapshot)
-        fd.close()
-        pathlib.Path(fd.name).replace(target)
-        snapshot_ok = True
-    except OSError:
-        if fd is not None:
-            try:
-                fd.close()
-            except OSError:
-                pass
-            try:
-                os.unlink(fd.name)
-            except OSError:
-                pass
+    snapshot_ok = atomic_write_text(target, snapshot)
 
     # History must stay aligned with the latest snapshot (avoid BRN/CTR vs stale JSON)
     if not snapshot_ok:
@@ -341,31 +323,13 @@ def write_shared_state(data: dict):
 
 
 def _trim_history(path: pathlib.Path):
-    fd = None
     raw = safe_read(path, HISTORY_READ_MAX)
     if raw is None:
         return
-    try:
-        lines = raw.decode("utf-8", errors="replace").splitlines()
-        if len(lines) > HISTORY_TRIM_TO:
-            trimmed = "\n".join(lines[-HISTORY_TRIM_TO:]) + "\n"
-            fd = tempfile.NamedTemporaryFile(
-                dir=path.parent, suffix=".tmp", delete=False,
-                mode="w", encoding="utf-8",
-            )
-            fd.write(trimmed)
-            fd.close()
-            pathlib.Path(fd.name).replace(path)
-    except OSError:
-        if fd is not None:
-            try:
-                fd.close()
-            except OSError:
-                pass
-            try:
-                os.unlink(fd.name)
-            except OSError:
-                pass
+    lines = raw.decode("utf-8", errors="replace").splitlines()
+    if len(lines) > HISTORY_TRIM_TO:
+        trimmed = "\n".join(lines[-HISTORY_TRIM_TO:]) + "\n"
+        atomic_write_text(path, trimmed)
 
 
 if __name__ == "__main__":

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1571,6 +1571,18 @@ class TestParseVersion(unittest.TestCase):
 
 class TestRlsBlink(unittest.TestCase):
 
+    def setUp(self):
+        # Restore blink globals after each test — test_toggles mutates them and
+        # leaked state could flip an unrelated test's first blink read (T-M-4).
+        import monitor
+        self._old_blink_last = monitor._rls_blink_last
+        self._old_blink_on = monitor._rls_blink_on
+
+    def tearDown(self):
+        import monitor
+        monitor._rls_blink_last = self._old_blink_last
+        monitor._rls_blink_on = self._old_blink_on
+
     def test_returns_bool(self):
         self.assertIsInstance(_rls_blink(), bool)
 
@@ -2104,6 +2116,46 @@ class TestLoadState(unittest.TestCase):
         p.write_bytes(b"{}" + b" " * MAX_FILE_SIZE)
         result = load_state(sid)
         self.assertIsNone(result)
+
+    def _write_snapshot(self, sid, payload):
+        p = pathlib.Path(self._tmp) / f"{sid}.json"
+        p.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_current_schema_version_is_readable(self):
+        """A snapshot tagged with the current _schema_version loads normally."""
+        import shared
+        sid = "curSchema"
+        self._write_snapshot(sid, {"session_id": sid, "_schema_version": shared.SCHEMA_VERSION})
+        result = load_state(sid)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["session_id"], sid)
+
+    def test_newer_schema_version_degrades_to_none(self):
+        """IPC schema gate (M-cross-2): a snapshot from a newer build than this
+        one may be shaped incompatibly, so load_state must refuse it (None)
+        rather than risk misreading fields."""
+        import shared
+        sid = "newSchema"
+        self._write_snapshot(sid, {"session_id": sid, "_schema_version": shared.SCHEMA_VERSION + 1})
+        self.assertIsNone(load_state(sid))
+
+    def test_missing_schema_version_stays_readable(self):
+        """Pre-versioning snapshots (no tag, e.g. left on disk after a git pull)
+        default to schema 0 and must remain readable — no hard break."""
+        sid = "noSchema"
+        self._write_snapshot(sid, {"session_id": sid, "cost": {"total_cost_usd": 1.0}})
+        result = load_state(sid)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["session_id"], sid)
+
+    def test_non_int_schema_version_is_ignored(self):
+        """A non-integer _schema_version (corrupt/manual edit) is not a valid
+        version claim — the gate ignores it and the snapshot stays readable."""
+        sid = "badSchema"
+        self._write_snapshot(sid, {"session_id": sid, "_schema_version": "weird"})
+        result = load_state(sid)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["session_id"], sid)
 
 
 # ---------------------------------------------------------------------------
@@ -3012,6 +3064,40 @@ class TestAuditRegressionV1105(unittest.TestCase):
             f"monitor.py is {loc} LOC, past the 3500-line audit trigger. "
             f"Open an ADR (see PROJECTS/cc-aio-mon/ROZHODNUTIA.md) before "
             f"adding more, OR raise this trigger after the ADR is filed."
+        )
+
+    def test_h1_render_loop_catches_attributeerror(self):
+        """H-1 defense-in-depth: the main() render loop's except guarding
+        flush(render_frame(...)) must include AttributeError, so a corrupt
+        snapshot (e.g. None.get(...) from an explicit JSON null) degrades to a
+        counted render error instead of crashing the tick. Pins the v1.12.4 fix
+        against silent removal of AttributeError from the catch tuple."""
+        import ast
+        import monitor
+        src = pathlib.Path(monitor.__file__).read_text(encoding="utf-8")
+        main_fn = next(
+            n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef) and n.name == "main"
+        )
+        found = False
+        for node in ast.walk(main_fn):
+            if not isinstance(node, ast.Try):
+                continue
+            dump = ast.dump(node)
+            if "flush" not in dump or "render_frame" not in dump:
+                continue
+            for handler in node.handlers:
+                exc = handler.type
+                names = []
+                if isinstance(exc, ast.Tuple):
+                    names = [e.id for e in exc.elts if isinstance(e, ast.Name)]
+                elif isinstance(exc, ast.Name):
+                    names = [exc.id]
+                if "AttributeError" in names:
+                    found = True
+        self.assertTrue(
+            found,
+            "main() render-loop except must catch AttributeError (H-1 defense-in-depth)"
         )
 
     def test_debt015_monitor_load_history_delegates_to_shared(self):

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -827,7 +827,7 @@ class TestWorkerLoopCrashRecovery(unittest.TestCase):
     a visible error rather than freezing at the last-good state. Without
     this branch the daemon thread would die silently. No prior test.
 
-    pulse.py:597-607
+    See pulse.py `_worker_loop` + `_crash_snapshot`.
     """
 
     def setUp(self):
@@ -842,47 +842,48 @@ class TestWorkerLoopCrashRecovery(unittest.TestCase):
             self._p._snapshot.clear()
             self._p._snapshot.update(self._orig_snapshot)
 
-    def test_refresh_exception_sets_worker_crashed_snapshot(self):
-        """When _refresh_once raises, the worker's except branch must
-        write a 'PULSE ERROR' / 'worker crashed' snapshot, not propagate."""
-
-        # We test the except-branch body without running the infinite loop:
-        # simulate one iteration where _refresh_once raises, then verify
-        # the snapshot reflects the crash. We do this by running the body
-        # of one iteration manually with _refresh_once patched.
-        import time as _time
-
-        # Drive a single iteration of the loop logic
-        with patch.object(self._p, "_refresh_once", side_effect=RuntimeError("simulated")):
-            # Inline the loop body once — this mirrors pulse._worker_loop without
-            # the `while True` so the test stays deterministic.
-            try:
-                self._p._refresh_once()
-            except Exception:
-                with self._p._snapshot_lock:
-                    self._p._snapshot.update({
-                        "t": _time.monotonic(),
-                        "wall_t": _time.time(),
-                        "score": None,
-                        "verdict": "PULSE ERROR",
-                        "level": "error",
-                        "reason": "worker crashed",
-                        "error": "worker crash",
-                    })
-
-        with self._p._snapshot_lock:
-            snap = dict(self._p._snapshot)
-        self.assertEqual(snap.get("verdict"), "PULSE ERROR")
-        self.assertEqual(snap.get("reason"), "worker crashed")
-        self.assertEqual(snap.get("level"), "error")
-        self.assertIsNone(snap.get("score"))
+    def test_crash_snapshot_clears_stale_fields(self):
+        """The worker last-resort crash payload must reset every data-bearing
+        field to its neutral init value — a 'PULSE ERROR' state must never
+        carry stale incidents/components/latency from the last healthy fetch
+        (M-cross-3). Asserts against the real _crash_snapshot() the worker
+        uses, not an inlined copy of the except body."""
+        crash = self._p._crash_snapshot()
+        # Crash markers
+        self.assertEqual(crash["verdict"], "PULSE ERROR")
+        self.assertEqual(crash["reason"], "worker crashed")
+        self.assertEqual(crash["level"], "error")
+        self.assertEqual(crash["error"], "worker crash")
+        # Every data-bearing field cleared to its init default
+        self.assertIsNone(crash["score"])
+        self.assertIsNone(crash["raw_score"])
+        self.assertIsNone(crash["indicator"])
+        self.assertEqual(crash["incidents"], [])
+        self.assertEqual(crash["components"], [])
+        self.assertIsNone(crash["latency_ms"])
+        self.assertIsNone(crash["latency_p50_ms"])
+        self.assertIsNone(crash["latency_p95_ms"])
+        # Drift guard: crash payload must cover exactly the keys the live
+        # snapshot tracks (a new _snapshot field forgotten here would fail).
+        self.assertEqual(set(crash), set(self._orig_snapshot))
 
     def test_worker_loop_actually_recovers_from_one_exception(self):
         """Integration: spin _worker_loop briefly with _refresh_once raising,
-        verify it reaches the except branch (snapshot mutates to crashed state)
-        and the thread keeps running (does not propagate the exception)."""
+        verify it reaches the except branch (snapshot mutates to crashed state),
+        clears any stale healthy-fetch data, and the thread keeps running
+        (does not propagate the exception)."""
         import threading
         import time as _time
+
+        # Seed a stale "all green" snapshot from a prior healthy fetch — the
+        # crash handler must wipe these so PULSE ERROR doesn't show green data.
+        with self._p._snapshot_lock:
+            self._p._snapshot.update({
+                "score": 100, "raw_score": 100, "indicator": "none",
+                "incidents": [{"name": "x", "impact": "minor"}],
+                "components": [{"name": "API", "status": "operational"}],
+                "latency_ms": 123.0, "latency_p50_ms": 120, "latency_p95_ms": 150,
+            })
 
         crashed_event = threading.Event()
         original_sleep = _time.sleep
@@ -907,6 +908,11 @@ class TestWorkerLoopCrashRecovery(unittest.TestCase):
             snap = dict(self._p._snapshot)
         self.assertEqual(snap.get("verdict"), "PULSE ERROR")
         self.assertEqual(snap.get("reason"), "worker crashed")
+        # Stale healthy-fetch data must be gone (M-cross-3)
+        self.assertEqual(snap.get("incidents"), [])
+        self.assertEqual(snap.get("components"), [])
+        self.assertIsNone(snap.get("latency_ms"))
+        self.assertIsNone(snap.get("indicator"))
 
 
 class TestAtomicReplaceLogOSErrorCleanup(unittest.TestCase):

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -467,6 +467,49 @@ class TestAcquireSingletonLock(unittest.TestCase):
         if result is not None:
             result.close()
 
+    def test_contention_across_processes(self):
+        """A separate OS process must not acquire a lock another process holds.
+        This is the real update.py-vs-monitor.py mutual exclusion guarantee
+        (CI-M-2) — the same-process test above cannot prove it because both
+        acquires share one interpreter. Spawns a child that tries to acquire."""
+        import subprocess
+        import sys
+        from shared import acquire_singleton_lock
+        repo_root = pathlib.Path(__file__).resolve().parent.parent
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = pathlib.Path(d) / "monitor.lock"
+            child = (
+                "import sys; sys.path.insert(0, %r);"
+                "from shared import acquire_singleton_lock;"
+                "fh = acquire_singleton_lock(%r);"
+                "print('ACQUIRED' if fh is not None else 'NONE')"
+                % (str(repo_root), str(lock_path))
+            )
+            # 1) Parent holds the lock → a child process must fail to acquire it.
+            fh1 = acquire_singleton_lock(lock_path)
+            try:
+                self.assertIsNotNone(fh1, "parent acquire must succeed")
+                r = subprocess.run(
+                    [sys.executable, "-c", child],
+                    capture_output=True, text=True, timeout=30,
+                )
+                self.assertEqual(
+                    r.stdout.strip(), "NONE",
+                    f"child must NOT acquire a held lock (stderr: {r.stderr})",
+                )
+            finally:
+                if fh1 is not None:
+                    fh1.close()
+            # 2) Once the parent releases, a fresh child process CAN acquire it.
+            r2 = subprocess.run(
+                [sys.executable, "-c", child],
+                capture_output=True, text=True, timeout=30,
+            )
+            self.assertEqual(
+                r2.stdout.strip(), "ACQUIRED",
+                f"child must acquire a free lock (stderr: {r2.stderr})",
+            )
+
 
 class TestRotateCrashLog(unittest.TestCase):
     """shared.rotate_crash_log — rotates oversized crash logs."""

--- a/update.py
+++ b/update.py
@@ -15,6 +15,7 @@ import datetime
 import signal
 import sys
 from pathlib import Path
+from typing import List, Optional, Tuple
 from shared import (
     VERSION_RE, MAX_FILE_SIZE, _sanitize, run_git as _shared_run_git,
     ensure_utf8_stdout, extract_changelog_entry, PY_FILES, safe_read,
@@ -116,7 +117,7 @@ def fetch_remote():
     ok("Fetched from origin")
 
 
-def get_local_version():
+def get_local_version() -> str:
     source = REPO_ROOT / "shared.py"
     if not source.exists():
         raise RuntimeError("shared.py not found")
@@ -130,7 +131,7 @@ def get_local_version():
     return m.group(1)
 
 
-def get_remote_version():
+def get_remote_version() -> str:
     r = run_git(["show", "origin/main:shared.py"])
     if r.returncode != 0:
         raise RuntimeError("Failed to read remote shared.py")
@@ -140,7 +141,7 @@ def get_remote_version():
     return m.group(1)
 
 
-def get_ahead_behind():
+def get_ahead_behind() -> Tuple[int, int]:
     """Return (behind, ahead) relative to origin/main."""
     r = run_git(["rev-list", "--left-right", "--count", "HEAD...origin/main"])
     if r.returncode != 0:
@@ -152,14 +153,14 @@ def get_ahead_behind():
     return behind, ahead
 
 
-def get_new_commits():
+def get_new_commits() -> List[str]:
     r = run_git(["log", "--oneline", "HEAD..origin/main"])
     if r.returncode != 0:
         return []
     return [line for line in r.stdout.strip().split("\n") if line]
 
 
-def get_remote_changelog_entry(version):
+def get_remote_changelog_entry(version: str) -> Optional[str]:
     r = run_git(["show", "origin/main:CHANGELOG.md"])
     if r.returncode != 0:
         return None


### PR DESCRIPTION
## v1.12.5 — audit #3 remediation

Remediation of the 9-dimension multidimensional audit on v1.12.4 (adversarially verified). See `CHANGELOG.md` for the user-facing entry.

### User-visible fixes
- **pulse**: clear stale `incidents`/`components`/`latency`/`scores` in the worker last-resort crash handler — `PULSE ERROR` no longer shows last-good "all green" data during a real outage (M-cross-3).
- **monitor**: refuse to quit (`q`) while a self-update is in flight, so the daemon can't be killed after `git pull --ff-only` but before the post-pull syntax check (M-cross-1).
- **monitor**: `load_state()` gates on `_schema_version`, refusing a snapshot tagged newer than the running build instead of misreading it (M-cross-2).

### Internal / quality (no user-visible change)
- Extract `shared.atomic_write_text()` (dedup 3× temp-file scaffold, M-2); drop dead `_MODEL_PATTERNS`; `f_cd` magic numbers → `SECONDS_*`; `PulseSnapshot` TypedDict + public-API type hints (pulse/update).

### Tests
+6 → **617** (schema-gate ×4, H-1 render-catch AST guard, cross-process singleton-lock). Pulse crash test no longer inlines production code.

### CI / tooling
`release-smoke.yml` E2E self-update happy-path (CI-H-1); bandit SARIF-report guard; pre-push PKCS#8 pattern; `scripts/release.sh` pre-flight.

### Docs
v1.12.3→v1.12.4 drift fix; ARCHITECTURE pulse lock inventory + lock-failure asymmetry; RELEASE PR-flow + blast-radius; FILE-IPC/CONFIGURATION line-ref → symbol-ref sweep; README `docs/` links + in-monitor `u`→`a` flow; baseline 611→617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)