### PR TITLE
chore(release): v1.14.0 — cross-model review remediation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,3 @@ docs/audits/
 .full-review/
 
 # Serena (lokálny LSP/memory state — nekomitovať)
-.serena/

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ notes.md
 # Audit tooling — LOCAL ONLY, must never reach GitHub
 docs/audits/
 .full-review/
+
+# Serena (lokálny LSP/memory state — nekomitovať)
+.serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## v1.14.0 — 2026-06-10
+
+Cross-model review remediation: an independent multi-dimensional review of
+v1.13.0; every finding was verified against the code before fixing.
+
+**Features:**
+- **Model table: Fable 5 and Opus 4.8 pricing entries** (`monitor.py:_MODELS`)
+  — cost estimates for the newest models; the retired Haiku 3.5 entry stays
+  for correct pricing of historical transcripts.
+- **Gauge-ceiling env vars documented:** `CC_MON_BRN_MAX` / `CC_MON_CTR_MAX` /
+  `CC_MON_CST_MAX` (docs/CONFIGURATION.md); FILE-IPC contract now names the
+  model-ID field correctly (`model.id`, drives cost-estimate pricing).
+
+**Security:**
+- **Self-update origin pinning.** Both the `update.py` CLI and the TUI update
+  modal verify `git remote get-url origin` against the canonical
+  `iM3SK/cc-aio-mon` repo before any `git pull`
+  (`shared.verify_origin_remote`) — a rewritten origin can no longer feed the
+  self-updater foreign code. Forks: set the new **`CC_AIO_MON_REMOTE`** env
+  var to your remote URL (see docs/CONFIGURATION.md).
+- **TUI apply now enforces the CLI safety guards.** `_apply_update_worker`
+  re-runs the checks (branch, clean tree, divergence, pinned origin) and
+  blocks the pull on any warning; the modal's `apply (risky)` action became
+  `apply (blocked by warnings above)`. Previously the warning list was
+  advisory-only and `a` pulled anyway.
+- **git resolved to an absolute path at import** (`shared.run_git`). A bare
+  `"git"` argv was re-resolved at every call — on Windows CreateProcess even
+  consults the CWD, so a `git.exe` planted in the repo root could win.
+- **TOCTOU guard in `_aggregate_session_cost`** (CWE-367): fstat identity
+  check after open, same pattern `_scan_ai_title` already used.
+- **Junction-safe subagents scan.** `_subagents_dir_for` and the `workflows/`
+  subdir check now use `shared.is_safe_dir`, which rejects NTFS junctions —
+  the previous `S_ISLNK`/`is_symlink()` tests missed them, allowing a junction
+  to point the scan outside `~/.claude/projects`.
+
+**Bug fixes:**
+- **Malformed transcript records can no longer crash the monitor.** A JSONL
+  record whose `message` is a *string* containing the substring "usage" made
+  `msg.get()` raise `AttributeError` past the OSError-only handler, killing
+  the stats modal and the monitor. Both transcript aggregators now type-check
+  `message` / `usage` / `model` and skip bad records.
+- **Timestamps parse timezone-aware.** `_parse_ts` used to strip `Z`/offsets
+  and parse the wall-clock as *local* time, shifting cutoff filters and daily
+  aggregation by the local UTC offset. Now `Z` maps to `+00:00` and offsets
+  are honoured (naive fallback kept for unparseable shapes).
+- **History trim can no longer lose a concurrent append.** The statusline
+  history append and the read→rewrite trim are serialized via a
+  `<sid>.jsonl.lock` sidecar (new `shared.lock_file_handle` /
+  `unlock_file_handle`, fcntl/msvcrt); the trim also drops malformed JSON
+  lines, matching what the FILE-IPC contract already promised.
+- **Fail-fast when the data dir is unusable.** The interactive monitor and
+  `update.py --apply` exit with a clear error instead of silently proceeding
+  without the singleton lock (IPC-contract violation: racing instances /
+  file replacement against a live monitor).
+- **`load_state()` rejects reserved SIDs** (`rls`/`stats`/`pulse`) per the
+  FILE-IPC contract, matching `list_sessions` / `load_history`.
+- **Windows HANDLE truncation fixed in monitor and update.**
+  `GetStdHandle`/`GetConsoleMode`/`SetConsoleMode` get explicit
+  `restype`/`argtypes` (a pointer-sized HANDLE was truncated to c_int on
+  64-bit Windows); a failed VT enable in `update.py` now disables colors
+  instead of spraying raw escape sequences.
+- **`_window_buf` off-by-one at `rows=1`** — emitted 2 lines into a 1-row
+  terminal; now exactly one.
+
+**Docs & tests:**
+- FILE-IPC contract corrections: `pulse.jsonl` is persistence-only (the modal
+  renders from in-memory `get_pulse_snapshot()`, not the file); snapshots
+  tagged with a newer `_schema_version` *are* gated by `load_state()`; the
+  new history lock sidecar is documented.
+- `CC_AIO_MON_REMOTE` documented in docs/CONFIGURATION.md; new shared helpers
+  added to the CONTRIBUTING.md SSoT list.
+- **+10 tests (688 total):** aggregator type guards, origin pinning (4 cases),
+  blocked TUI apply, trim malformed-line drop, `rows=1` window, reserved-SID
+  snapshots, absolute git argv, lock round-trip; the `_env_pct` test no
+  longer leaks env state between tests.
+
 ## v1.13.0 — 2026-06-04
 
 **Features:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@
 When changing the JSON shape that `statusline.py` writes and `monitor.py` reads:
 
 1. Bump `shared.SCHEMA_VERSION` (currently `1`).
-2. Document the new field or structural change in [docs/FILE-IPC-CONTRACT.md](FILE-IPC-CONTRACT.md).
+2. Document the new field or structural change in [docs/FILE-IPC-CONTRACT.md](docs/FILE-IPC-CONTRACT.md).
 3. Read new fields via `dict.get(key, default)` so older snapshots (without the field) remain loadable — forward-compat reads are required, not optional.
 
 ## Pull requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
    `unittest discover tests/`, so the `py tests.py` invocation continues to work
    unchanged.
 
-   **Baseline: 678 tests passing (3 skipped on platforms missing optional artifacts).**
+   **Baseline: 688 tests passing (3 skipped on platforms missing optional artifacts).**
    Contributions must not reduce the passing count without explanation. If you add
    tests, put them in the file that matches the module under test — helpers go in
    `test_shared.py`, TUI logic in `test_monitor.py`, and so on.
@@ -47,7 +47,7 @@
 - **`shared.py` is the single source of truth** — all cross-file constants, helpers, ANSI palette, and regexes live there. Never duplicate a literal or a helper in `statusline.py` / `monitor.py` / `pulse.py` / `update.py`. The shared surface includes:
   - **Constants:** `VERSION`, `PY_FILES`, `_SID_RE`, `_ANSI_RE`, `MIN_EPOCH`, `MAX_FILE_SIZE`, `HISTORY_READ_MAX`, `HISTORY_AGGREGATE_MAX`, `TRANSCRIPT_MAX_BYTES`, `DATA_DIR`, `DATA_DIR_NAME`, `VERSION_RE`, `RESERVED_SIDS`, `WARN_PCT`, `CRIT_PCT`.
   - **ANSI palette:** `E`, `R`, `B`, `C_RED`, `C_GRN`, `C_YEL`, `C_ORN`, `C_CYN`, `C_WHT`, `C_DIM`.
-  - **Helpers:** `_num`, `_sanitize`, `safe_read`, `f_tok`, `f_cost`, `f_dur`, `f_cd`, `char_width`, `is_safe_dir`, `ensure_data_dir`, `ensure_utf8_stdout`, `load_history`, `strip_context_suffix`, `compact_context_suffix`, `badge_context_suffix`, `extract_changelog_entry`, `run_git`, `calc_rates`, `atomic_write_text`, `acquire_singleton_lock`, `check_syntax_after_pull`, `parse_ahead_behind`, `rotate_crash_log`.
+  - **Helpers:** `_num`, `_sanitize`, `safe_read`, `f_tok`, `f_cost`, `f_dur`, `f_cd`, `char_width`, `is_safe_dir`, `ensure_data_dir`, `ensure_utf8_stdout`, `load_history`, `strip_context_suffix`, `compact_context_suffix`, `badge_context_suffix`, `extract_changelog_entry`, `run_git`, `verify_origin_remote`, `calc_rates`, `atomic_write_text`, `acquire_singleton_lock`, `lock_file_handle`, `unlock_file_handle`, `check_syntax_after_pull`, `parse_ahead_behind`, `rotate_crash_log`.
   - If you add a helper or constant that is (or could be) used by more than one module, put it in `shared.py` from day one.
   - **No parallel implementations** — a regression-guard test (`tests/test_shared.py::TestPyFilesSingleSourceOfTruth`) fails if the post-pull syntax-check loop reappears inline in `monitor.py` or `update.py` instead of delegating to `shared.check_syntax_after_pull`. Apply the same discipline to any future helper: extract to `shared.py`, have both consumers delegate.
   - **Documented SSoT exception — `update.py` ANSI palette.** `update.py` defines its own basic 16-color palette (`GRN`, `YEL`, `RED`, `CYN`, `DIM`, `R`) instead of importing the Nord 24-bit truecolor `C_*` set from `shared.py`. Reason: `update.py` runs *before* any TUI / VT enablement and must remain readable on minimal terminals without 24-bit truecolor support (legacy Windows console, recovery shells). Truecolor escapes would render as garbled sequences there. If you change either palette, keep them independently consistent and update the comment block above `GRN = YEL = RED = ...` in `update.py`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -44,6 +44,43 @@ If you add a new env var, add it here in the same commit.
 - **When to set:** offline use, restricted egress, CI environments,
   privacy-sensitive setups that should not emit any outbound HTTP.
 
+### `CC_AIO_MON_REMOTE`
+
+- **Type:** string (git remote URL, exact match)
+- **Default:** unset → `origin` must point at the canonical
+  `iM3SK/cc-aio-mon` GitHub repo (https / ssh forms accepted)
+- **Read by:** `shared.py` (`verify_origin_remote`), enforced by the
+  `update.py` CLI and the monitor's update modal before any `git pull`
+- **Effect:** overrides the pinned-origin check for self-update. Set it to
+  your fork's remote URL (must match `git remote get-url origin` exactly)
+  to keep self-update working on a fork.
+- **When to set:** forks only. Leave unset otherwise — the pin is a
+  supply-chain guard (a rewritten `origin` cannot feed the updater foreign
+  code).
+
+### `CC_MON_BRN_MAX`
+
+- **Type:** float ($/min)
+- **Default:** `10.0`
+- **Read by:** `monitor.py` (`_env_float` → `BRN_MAX`, `monitor.py:731`)
+- **Effect:** ceiling of the `BRN` progress bar and the `BRN OVER TIME`
+  axis. Raise if the bar pins (e.g. 24/7 Opus API workloads).
+
+### `CC_MON_CTR_MAX`
+
+- **Type:** float (%/min)
+- **Default:** `10.0`
+- **Read by:** `monitor.py` (`_env_float` → `CTR_MAX`, `monitor.py:732`)
+- **Effect:** ceiling of the `CTR` (context consumption rate) bar.
+
+### `CC_MON_CST_MAX`
+
+- **Type:** float ($)
+- **Default:** `1000.0`
+- **Read by:** `monitor.py` (`_env_float` → `CST_MAX`, `monitor.py:733`)
+- **Effect:** ceiling of the `CST` (session cost) bar. Raise for
+  long-running API sessions.
+
 ---
 
 ## Threshold variables (legacy `CLAUDE_*` prefix)
@@ -77,9 +114,9 @@ shells; new thresholds go under `CC_AIO_MON_*`.
 - **Default:** `3.0`
 - **Read by:** `monitor.py` (`_env_float` → `WARN_BRN`)
 - **Effect:** burn-rate threshold above which the `BRN` segment switches
-  to its alert color. The dashboard `BRN OVER TIME` axis is fixed at
-  `0–10 $/min` regardless of this value (axis is set by `BRN_MAX`, not
-  the warn threshold).
+  to its alert color. The dashboard `BRN OVER TIME` axis defaults to
+  `0–10 $/min` regardless of this value (axis is set by `BRN_MAX`,
+  overridable via `CC_MON_BRN_MAX`, not the warn threshold).
 
 ---
 

--- a/docs/FILE-IPC-CONTRACT.md
+++ b/docs/FILE-IPC-CONTRACT.md
@@ -187,9 +187,9 @@ def load_state(sid):
 |---|---|---|---|
 | `_schema_version` | int | statusline.write_shared_state() | Contract version (current: 1); added at write time |
 | `session_id` | str | Claude Code (stdin) | Session name / UUID passed by CC; validated & defaulted to "default" if invalid |
-| `model` | dict | CC | Model metadata: `{display_name, name, ...}` |
+| `model` | dict | CC | Model metadata: `{display_name, id, ...}` |
 | `model.display_name` | str | CC | Human-readable model name, e.g. "Opus 4.7 (1M context)" |
-| `model.name` | str | CC | Internal model ID, e.g. "claude-opus-4-1-20250805" |
+| `model.id` | str | CC | Internal model ID, e.g. "claude-opus-4-1-20250805"; drives cost-estimate pricing |
 | `context_window` | dict | CC | `{context_window_size: int, used_percentage: 0–100, ...}` |
 | `context_window.context_window_size` | int | CC | Total context tokens available (e.g., 200000) |
 | `context_window.used_percentage` | float | CC | 0–100; monitor displays as "CTX NN%" |
@@ -251,6 +251,14 @@ After successful snapshot write:
 2. Each line: `{**snapshot_dict, "_schema_version": SCHEMA_VERSION, "t": time.time()}`
 3. No fsync (relies on OS buffering + rename for atomicity)
 4. Check file size after write; if `> MAX_FILE_SIZE`, call `_trim_history()`
+
+**Concurrency**: the append and the read→rewrite trim are serialized via a
+sidecar lock file `<sid>.jsonl.lock` (`shared.lock_file_handle()` — fcntl on
+Unix, msvcrt on Windows). Without it, a concurrent statusline append landing
+between the trim's read and its atomic replace would be silently lost. Lock
+failure degrades to the unlocked best-effort behaviour. The sidecar is tiny,
+never cleaned up, and is not a session file (no `.json`/`.jsonl` glob matches
+it).
 
 **Trim Policy** (`statusline.py`):
 
@@ -317,7 +325,7 @@ Each line is a JSON object with these fields:
 
 **Example Line**:
 ```json
-{"session_id":"default","model":{"display_name":"Opus 4.7","name":"claude-opus-4-1-20250805"},"context_window":{"context_window_size":200000,"used_percentage":45.5},"cost":{"total_cost_usd":0.15},"rate_limits":{"five_hour":{"used_percentage":10,"resets_at":1716379200},"seven_day":{"used_percentage":5,"resets_at":1716639600}},"_schema_version":1,"t":1716292800.123}
+{"session_id":"default","model":{"display_name":"Opus 4.7","id":"claude-opus-4-1-20250805"},"context_window":{"context_window_size":200000,"used_percentage":45.5},"cost":{"total_cost_usd":0.15},"rate_limits":{"five_hour":{"used_percentage":10,"resets_at":1716379200},"seven_day":{"used_percentage":5,"resets_at":1716639600}},"_schema_version":1,"t":1716292800.123}
 ```
 
 ### File Size Management
@@ -340,7 +348,7 @@ Each line is a JSON object with these fields:
 
 ### Purpose
 
-Persistent log of Anthropic API stability samples (fetched every 30 sec). Used by monitor to display "API Status" section + trend graphs.
+Persistent log of Anthropic API stability samples (fetched every 30 sec). **Not a reader IPC channel**: the monitor renders the pulse modal from the in-process `pulse.get_pulse_snapshot()` (thread-safe in-memory read), never from this file. `pulse.jsonl` exists for persistence across restarts (startup seeding/cleanup) and for external tooling.
 
 ### Full Path
 
@@ -661,7 +669,7 @@ Multiple `--list` invocations can run concurrently with monitor or each other.
 Monitor reads via `dict.get("_schema_version")` → defaults to `None` if absent:
 - Pre-v1.10 snapshots (no `_schema_version` field) are tolerated
 - Unknown fields in snapshots are silently ignored (defensive dict.get)
-- Unknown future `_schema_version` values are not yet gated (future-proofing only)
+- Unknown future `_schema_version` values **are gated**: `monitor.load_state()` returns `None` for snapshots tagged with an int `_schema_version` greater than this build's `SCHEMA_VERSION` (UI shows "no data" until the monitor restarts post-update)
 
 ### Forward Compatibility (Future)
 
@@ -723,7 +731,7 @@ No deprecated fields yet. When a field is retired:
 |---|---|---|---|---|---|
 | `<sid>.json` | Session snapshot | statusline | monitor | Atomic replace | Until session expires (~1h idle in monitor) |
 | `<sid>.jsonl` | Session history | statusline | statusline (rates), monitor (trends) | Atomic trim; non-atomic append | Trimmed to 1000 lines @ 1 MB |
-| `pulse.jsonl` | API stability log | pulse.py (worker) | monitor (display), external tools | Atomic trim; non-atomic append | Trimmed to 500 lines @ 1 MB; startup cleanup drops >24h entries |
+| `pulse.jsonl` | API stability log (persistence only — monitor displays from in-memory `get_pulse_snapshot()`) | pulse.py (worker) | pulse.py (startup seed), external tools | Atomic trim; non-atomic append | Trimmed to 500 lines @ 1 MB; startup cleanup drops >24h entries |
 | `monitor-crash.log` | Crash traceback | monitor (excepthook) | User (post-mortem) | None (diagnostic only) | Rotated to `.log.1` on every crash (v1.12.2+); size guard still applies for non-crash callers |
 | `monitor.lock` | Singleton lock | monitor | monitor (check at startup) | Atomic fcntl/msvcrt | Process lifetime; auto-released on exit |
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -62,7 +62,7 @@ Work through these in order before creating any tag.
   python3 tests.py     # macOS / Linux
   ```
   `tests.py` is a thin wrapper that runs `unittest discover tests/`
-  (`tests.py:main()`). Current baseline: **678 passing** (v1.13.0). The new
+  (`tests.py:main()`). Current baseline: **688 passing** (v1.14.0). The new
   release's count must be >= this number unless tests were intentionally
   removed (document the removal in CHANGELOG).
 

--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -65,7 +65,7 @@ alias mon='python3 ~/.cc-aio-mon/monitor.py'
 
 ## Requirements check (optional)
 
-[check-requirements.sh](check-requirements.sh) is an optional read-only script that verifies your system has Python, Git, and Claude Code CLI installed. It makes no changes to your system.
+[check-requirements.sh](../check-requirements.sh) is an optional read-only script that verifies your system has Python, Git, and Claude Code CLI installed. It makes no changes to your system.
 
 Run from the repo directory:
 

--- a/docs/setup-macos.md
+++ b/docs/setup-macos.md
@@ -62,7 +62,7 @@ alias mon='python3 ~/.cc-aio-mon/monitor.py'
 
 ## Requirements check (optional)
 
-[check-requirements.sh](check-requirements.sh) is an optional read-only script that verifies your system has Python, Git, and Claude Code CLI installed. It makes no changes to your system.
+[check-requirements.sh](../check-requirements.sh) is an optional read-only script that verifies your system has Python, Git, and Claude Code CLI installed. It makes no changes to your system.
 
 Run from the repo directory:
 

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -67,7 +67,7 @@ function mon { py "$env:USERPROFILE\.cc-aio-mon\monitor.py" @args }
 
 ## Requirements check (optional)
 
-[check-requirements.ps1](check-requirements.ps1) is an optional read-only script that verifies your system has Python, Git, and Claude Code CLI installed. It makes no changes to your system.
+[check-requirements.ps1](../check-requirements.ps1) is an optional read-only script that verifies your system has Python, Git, and Claude Code CLI installed. It makes no changes to your system.
 
 Run from the repo directory:
 

--- a/monitor.py
+++ b/monitor.py
@@ -67,7 +67,7 @@ from shared import (calc_rates, _num, _sanitize, safe_read, f_tok, f_cost, f_dur
                     RESERVED_SIDS, strip_context_suffix, compact_context_suffix,
                     badge_context_suffix,
                     extract_changelog_entry,
-                    check_syntax_after_pull, parse_ahead_behind,
+                    check_syntax_after_pull, parse_ahead_behind, verify_origin_remote,
                     rotate_crash_log, acquire_singleton_lock,
                     E, R, B, C_RED, C_GRN, C_YEL, C_ORN, C_CYN, C_WHT, C_DIM)
 import pulse
@@ -85,7 +85,18 @@ def _parse_ts(ts_str):
     if not ts_str:
         return 0
     try:
-        # Strip timezone suffix for 3.8 compat: Z, +HH:MM, -HH:MM
+        # Timezone-aware parse. 3.8's fromisoformat() accepts ±HH:MM offsets
+        # but not "Z", so map Z → +00:00. Stripping the offset and parsing
+        # naive (pre-fix behaviour) interpreted the wall-clock as *local*
+        # time, shifting cutoff filters and daily aggregation by the local
+        # UTC offset.
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        pass
+    try:
+        # Fallback for shapes fromisoformat can't parse with an offset
+        # attached (e.g. non-colon offsets on 3.8): strip the suffix and
+        # parse naive — approximate, but better than dropping the record.
         clean = ts_str.replace("Z", "")
         # Remove +/-offset after the time portion (T required)
         t_pos = clean.find("T")
@@ -189,14 +200,19 @@ def _aggregate_transcript(jl, st, sid, is_subagent, cutoff,
 
                 if obj.get("type") != "assistant":
                     continue
+                # `"usage" in msg` on a *string* message is a substring test —
+                # msg.get() would then raise AttributeError, which the outer
+                # except (OSError, UnicodeDecodeError) does not catch.
                 msg = obj.get("message")
-                if not msg or "usage" not in msg:
+                if not isinstance(msg, dict) or "usage" not in msg:
                     continue
 
                 model = msg.get("model") or "unknown"
-                if model.startswith("<"):
+                if not isinstance(model, str) or model.startswith("<"):
                     continue  # skip synthetic/internal entries
                 u = msg["usage"]
+                if not isinstance(u, dict):
+                    continue
                 inp = int(_num(u.get("input_tokens", 0)))
                 out = int(_num(u.get("output_tokens", 0)))
                 cr = int(_num(u.get("cache_read_input_tokens", 0)))
@@ -454,10 +470,18 @@ if IS_WIN:
         except Exception:
             pass
         try:
+            # HANDLE is pointer-sized — the default ctypes restype (c_int)
+            # truncates/sign-extends it on 64-bit Windows and the console-mode
+            # calls then operate on a corrupted handle (same fix as
+            # statusline's CONOUT$ branch and update.py's VT enable).
+            kernel32.GetStdHandle.restype = ctypes.c_void_p
+            kernel32.GetConsoleMode.argtypes = [
+                ctypes.c_void_p, ctypes.POINTER(ctypes.c_ulong)]
+            kernel32.SetConsoleMode.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
             handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
         except Exception:
             sys.exit(_WIN10_ANSI_REQUIRED_MSG)
-        if handle == -1 or handle == 0:
+        if handle is None or handle == 0 or handle == ctypes.c_void_p(-1).value:
             sys.exit(_WIN10_ANSI_REQUIRED_MSG)
         mode = ctypes.c_ulong(0)
         if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
@@ -1064,7 +1088,10 @@ def list_sessions():
 
 
 def load_state(sid):
-    if not _SID_RE.match(str(sid)):
+    # FILE-IPC "Invalid SID Handling": reserved stems (rls/stats/pulse) are
+    # internal files, never session snapshots — early-return like
+    # list_sessions / load_history already do.
+    if sid in RESERVED_SIDS or not _SID_RE.match(str(sid)):
         return None
     if not is_safe_dir(DATA_DIR):
         return None
@@ -1197,6 +1224,15 @@ def _window_buf(buf, rows, header_n=_MODAL_HEADER_LINES):
     rows = max(1, rows)
     if len(buf) <= rows:
         _modal_scroll = 0
+        return buf
+    if rows == 1:
+        # rows=1: no room for header or indicator — emit exactly one body
+        # line at the scroll offset (the general math below always reserves
+        # an indicator line, which would emit 2 lines into a 1-row terminal).
+        body = buf[header_n:] or buf
+        off = min(max(0, _modal_scroll), len(body) - 1)
+        _modal_scroll = off
+        buf[:] = body[off:off + 1]
         return buf
     # Cap pinned-header lines at rows-2 (reserve >=1 body + 1 indicator line) so
     # the emitted head+window+indicator never exceeds the terminal height on a
@@ -1555,9 +1591,13 @@ _DEFAULT_PRICING = {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_wri
 # Single source of truth for model metadata — keyed by Anthropic model ID.
 # Each entry: {"name": "...", "code": ("XX", "V.v"), "pricing": {...} | None}
 # Pricing is per-1M-token USD (input / output / cache_read / cache_write).
-# Adding a new model = one entry here, not three. Used by _get_pricing (below),
-# _model_code / _model_label (token-stats modal section, ~line 2200).
+# Adding a new model = one entry here, not three. Used by _get_pricing (below)
+# and _model_code (token-stats modal section).
 _MODELS = {
+    "claude-fable-5": {"name": "Fable 5", "code": ("FA", "5"),
+                       "pricing": {"input": 10.0, "output": 50.0, "cache_read": 1.00, "cache_write": 12.50}},
+    "claude-opus-4-8": {"name": "Opus 4.8", "code": ("OP", "4.8"),
+                        "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
     "claude-opus-4-7": {"name": "Opus 4.7", "code": ("OP", "4.7"),
                         "pricing": {"input": 5.0,  "output": 25.0, "cache_read": 0.50, "cache_write": 6.25}},
     "claude-opus-4-6": {"name": "Opus 4.6", "code": ("OP", "4.6"),
@@ -1572,6 +1612,7 @@ _MODELS = {
                           "pricing": {"input": 3.0,  "output": 15.0, "cache_read": 0.30, "cache_write": 3.75}},
     "claude-haiku-4-5-20251001": {"name": "Haiku 4.5", "code": ("HA", "4.5"),
                                    "pricing": {"input": 1.0,  "output": 5.0,  "cache_read": 0.10, "cache_write": 1.25}},
+    # Retired model — kept for correct pricing of historical transcripts.
     "claude-haiku-3-5": {"name": "Haiku 3.5", "code": ("HA", "3.5"),
                          "pricing": {"input": 0.8,  "output": 4.0,  "cache_read": 0.08, "cache_write": 1.00}},
     # Short-ID fallbacks (some transcript entries use abbreviated IDs). No pricing.
@@ -1680,7 +1721,7 @@ def _scan_ai_title(transcript_path):
             # S-P2-2 (CWE-367): TOCTOU mitigation — re-stat the *open*
             # file descriptor and require (st_ino, st_dev) to match the
             # pre-open stat. If they differ, the underlying inode was
-            # swapped between resolve() (line ~1250) and open(), which on
+            # swapped between resolve() (in _safe_transcript_path) and open(), which on
             # a shared filesystem could let another user point us at a
             # different file via fast unlink/link or symlink-flip races.
             # st_dev guard ensures the swap can't move us to a different
@@ -1759,10 +1800,10 @@ def _aggregate_session_cost(data):
         return None
 
     try:
-        size = path.stat().st_size
+        st = path.stat()
     except OSError:
         return None
-    if size > TRANSCRIPT_MAX_BYTES:
+    if st.st_size > TRANSCRIPT_MAX_BYTES:
         return None
 
     inp = out = cr = cw = 0.0
@@ -1771,6 +1812,15 @@ def _aggregate_session_cost(data):
     c1h = c5m = 0
     try:
         with path.open("r", encoding="utf-8", errors="replace") as f:
+            # S-P2-2 (CWE-367): TOCTOU guard — same fstat identity check as
+            # _scan_ai_title: if the inode/device pair diverged between the
+            # stat above and this open, the file was swapped underneath us.
+            try:
+                fst = os.fstat(f.fileno())
+            except OSError:
+                return None
+            if (fst.st_ino, fst.st_dev) != (st.st_ino, st.st_dev):
+                return None
             for line in f:
                 line = line.strip()
                 if not line or not line.startswith("{"):
@@ -1781,9 +1831,17 @@ def _aggregate_session_cost(data):
                     continue
                 if rec.get("type") != "assistant":
                     continue
+                # Same crash class as the stats-modal aggregator: a string
+                # "message" would turn the .get() calls into AttributeError.
                 msg = rec.get("message") or {}
+                if not isinstance(msg, dict):
+                    continue
                 u = msg.get("usage") or {}
+                if not isinstance(u, dict):
+                    u = {}
                 mid = msg.get("model") or ""
+                if not isinstance(mid, str):
+                    mid = ""
                 pricing = _get_pricing(mid)
                 # Per-record token deltas — name with cr_inc/cw_inc (not r/w)
                 # to avoid visual collision with module-level `R` ANSI reset.
@@ -2266,6 +2324,10 @@ def _update_checks():
             ahead = behind = 0
         if ahead > 0 and behind > 0:
             warns.append(f"Diverged: {ahead} ahead, {behind} behind origin/main")
+    # SEC: pin self-update to the canonical repo (same guard as update.py CLI).
+    remote_problem = verify_origin_remote(_REPO_ROOT)
+    if remote_problem:
+        warns.append(f"Origin check: {remote_problem}")
     return warns
 
 
@@ -2358,8 +2420,17 @@ def _get_update_result():
 
 
 def _apply_update_worker():
-    """Background worker: git pull --ff-only + syntax check. Sets _update_result."""
+    """Background worker: re-run safety checks, then git pull --ff-only +
+    syntax check. Sets _update_result. The checks mirror the update.py CLI
+    guards (branch / clean tree / divergence / pinned origin) — the modal
+    render is advisory only, so the worker must enforce them itself."""
     try:
+        warns = _update_checks()
+        if warns:
+            _set_update_result(
+                "Update blocked: " + "; ".join(_sanitize(w) for w in warns)
+            )
+            return
         rc, out, err = _git_cmd(["pull", "--ff-only", "origin", "main"], timeout=30)
         if rc == 0:
             # Drop modal git cache so post-pull state (no commits ahead, etc.)
@@ -2461,7 +2532,7 @@ def render_update_modal(cols, rows):
             buf.append(f"{C_DIM}press any key to close{R}")
         elif warns:
             buf.append(sep(SW))
-            buf.append(f"{C_DIM}[{R}{C_WHT}a{R}{C_DIM}] apply (risky){R}")
+            buf.append(f"{C_DIM}[{R}{C_WHT}a{R}{C_DIM}] apply (blocked by warnings above){R}")
             buf.append(f"{C_DIM}press any key to close{R}")
         else:
             buf.append(sep(SW))
@@ -2846,14 +2917,13 @@ def _subagents_dir_for(transcript_path):
     path = _safe_transcript_path(transcript_path)
     if path is None:
         return None
-    try:
-        d = path.parent / path.stem / "subagents"
-        st = d.lstat()
-        if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
-            return None
-        return d
-    except OSError:
+    d = path.parent / path.stem / "subagents"
+    # is_safe_dir = lstat + S_ISDIR + Windows reparse-point check. A plain
+    # S_ISLNK test misses NTFS junctions, which would let a junction point
+    # the subagent scan outside ~/.claude/projects.
+    if not is_safe_dir(d):
         return None
+    return d
 
 
 def scan_subagents(transcript_path, ttl=_SUBAGENTS_TTL):
@@ -2881,7 +2951,7 @@ def scan_subagents(transcript_path, ttl=_SUBAGENTS_TTL):
     try:
         files.extend(sorted(d.glob("agent-*.jsonl")))
         wf = d / "workflows"
-        if wf.is_dir() and not wf.is_symlink():
+        if is_safe_dir(wf):  # rejects symlinks AND Windows junctions
             files.extend(f for f in wf.glob("**/*.jsonl") if f.name != "journal.jsonl")
     except OSError:
         return None
@@ -3237,6 +3307,16 @@ def main():
                 f"Lock file: {DATA_DIR / 'monitor.lock'} (inspect for PID)\n"
                 "Close the other instance, or delete the lock file if it is stale."
             )
+    else:
+        # FILE-IPC contract: the interactive monitor must hold the singleton
+        # lock — running unlocked would race a second instance on snapshot
+        # polling and corrupt the crash log. No usable data dir also means no
+        # snapshots to render, so fail fast instead of degrading silently.
+        sys.exit(
+            f"Error: data directory unusable: {DATA_DIR}\n"
+            "Check permissions/ownership — the monitor needs it for IPC "
+            "snapshots and its singleton lock."
+        )
 
     # Terminal capability checks — must run before any ANSI output
     if not sys.stdout.isatty():

--- a/shared.py
+++ b/shared.py
@@ -7,6 +7,7 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import stat as _stat_mod
 import subprocess
 import sys
@@ -52,7 +53,7 @@ DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.13.0"
+VERSION = "1.14.0"
 
 # File-IPC contract version. Statusline writes this field on every snapshot
 # and history entry; bumped when the JSON shape changes incompatibly. Monitor's
@@ -357,15 +358,52 @@ def _git_env():
     return env
 
 
+# SEC (PATH injection): resolve git to an absolute path once at import. A bare
+# "git" argv is re-resolved at every call — on Windows CreateProcess even
+# consults the CWD, so a git.exe planted in the repo root would win. Pinning
+# the import-time resolution closes the call-time swap window.
+_GIT_BIN = shutil.which("git")
+
+
 def run_git(args: Iterable[str], cwd, timeout: float = 15) -> "subprocess.CompletedProcess[str]":
     """Safe git invocation with minimal env whitelist.
     Returns subprocess.CompletedProcess. Raises FileNotFoundError if git missing."""
+    if _GIT_BIN is None:
+        raise FileNotFoundError("git executable not found on PATH")
     return subprocess.run(
-        ["git"] + list(args),
+        [_GIT_BIN] + list(args),
         cwd=cwd, capture_output=True, text=True,
         encoding="utf-8", errors="replace",
         timeout=timeout, env=_git_env(),
     )
+
+
+# Canonical upstream for self-update. verify_origin_remote() pins `git pull`
+# to this repo so a rewritten origin can't feed the self-updater foreign code.
+# Forks: set CC_AIO_MON_REMOTE to your remote URL to keep self-update working.
+_CANONICAL_REMOTE_RE = re.compile(
+    r"^(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/)"
+    r"iM3SK/cc-aio-mon(?:\.git)?/?$",
+    re.IGNORECASE,
+)
+
+
+def verify_origin_remote(repo_root) -> Optional[str]:
+    """Return None when `origin` points at the canonical repo (or matches the
+    CC_AIO_MON_REMOTE override exactly), else a short problem description."""
+    try:
+        r = run_git(["remote", "get-url", "origin"], cwd=repo_root)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "git unavailable (missing or timed out)"
+    if r.returncode != 0:
+        return "origin remote not configured"
+    url = r.stdout.strip()
+    override = os.environ.get("CC_AIO_MON_REMOTE", "").strip()
+    if override:
+        return None if url == override else f"origin is {url}, expected {override}"
+    if _CANONICAL_REMOTE_RE.match(url):
+        return None
+    return f"unexpected origin URL: {url}"
 
 
 # ---------------------------------------------------------------------------
@@ -538,6 +576,39 @@ def acquire_singleton_lock(lock_path) -> Optional[IO]:
     except OSError:
         pass
     return fh
+
+
+def lock_file_handle(fh) -> bool:
+    """Blocking advisory exclusive lock on an open file handle.
+
+    Used to serialize short critical sections across processes (e.g. the
+    statusline history append vs. its read→rewrite trim). Returns True when
+    the lock is held; False when the platform refused it — callers proceed
+    unlocked as best effort. Pair with unlock_file_handle().
+    """
+    try:
+        if sys.platform == "win32":
+            # Lock byte 0 — locking a range past EOF is allowed on Windows,
+            # so an empty sidecar lock file works without a placeholder byte.
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        return True
+    except OSError:
+        return False
+
+
+def unlock_file_handle(fh) -> None:
+    """Release a lock taken by lock_file_handle(). Best effort."""
+    try:
+        if sys.platform == "win32":
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
 
 
 def calc_rates(hist: List[dict]) -> Tuple[Optional[float], Optional[float]]:

--- a/statusline.py
+++ b/statusline.py
@@ -23,6 +23,7 @@ import time
 from shared import (calc_rates as _calc_rates, _num, _sanitize, safe_read, atomic_write_text,
                     f_tok, f_cost, f_cd,
                     ensure_data_dir, ensure_utf8_stdout, load_history as _shared_load_history,
+                    lock_file_handle, unlock_file_handle,
                     _SID_RE, _ANSI_RE, MAX_FILE_SIZE, HISTORY_READ_MAX, HISTORY_RATE_SAMPLES,
                     DATA_DIR, RESERVED_SIDS, SCHEMA_VERSION,
                     strip_context_suffix, WARN_PCT, CRIT_PCT,
@@ -331,14 +332,24 @@ def write_shared_state(data: dict):
     if not snapshot_ok:
         return
 
-    # Append to history JSONL + trim if needed
+    # Append to history JSONL + trim if needed. Append and the read→rewrite
+    # trim are serialized via a sidecar lock file — without it, a concurrent
+    # statusline append landing between the trim's read and its atomic
+    # replace would be silently lost. Lock failure degrades to the old
+    # unlocked best-effort behaviour.
     hist = base / f"{sid}.jsonl"
     try:
-        with open(hist, "a", encoding="utf-8") as f:
-            f.write(entry + "\n")
-        # Trim based on actual file size
-        if hist.stat().st_size > MAX_FILE_SIZE:
-            _trim_history(hist)
+        with open(hist.with_name(hist.name + ".lock"), "a", encoding="utf-8") as lf:
+            locked = lock_file_handle(lf)
+            try:
+                with open(hist, "a", encoding="utf-8") as f:
+                    f.write(entry + "\n")
+                # Trim based on actual file size
+                if hist.stat().st_size > MAX_FILE_SIZE:
+                    _trim_history(hist)
+            finally:
+                if locked:
+                    unlock_file_handle(lf)
     except OSError:
         pass
 
@@ -349,7 +360,17 @@ def _trim_history(path: pathlib.Path):
         return
     lines = raw.decode("utf-8", errors="replace").splitlines()
     if len(lines) > HISTORY_TRIM_TO:
-        trimmed = "\n".join(lines[-HISTORY_TRIM_TO:]) + "\n"
+        kept = lines[-HISTORY_TRIM_TO:]
+        # FILE-IPC "Trim Policy": malformed JSON lines are dropped during the
+        # trim so a torn/corrupted line cannot survive rewrites forever.
+        valid = []
+        for ln in kept:
+            try:
+                json.loads(ln)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            valid.append(ln)
+        trimmed = "\n".join(valid) + "\n" if valid else ""
         atomic_write_text(path, trimmed)
 
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -702,10 +702,54 @@ class TestParseTs(unittest.TestCase):
         self.assertEqual(_parse_ts("not-a-date"), 0)
 
     def test_consistent_across_formats(self):
-        """Z and no-tz should produce the same result (both naive local)."""
-        a = _parse_ts("2026-04-12T17:23:27")
-        b = _parse_ts("2026-04-12T17:23:27Z")
-        self.assertEqual(a, b)
+        """Z is UTC, explicit offsets are honoured; no-tz parses naive local."""
+        from datetime import datetime as _dt, timezone as _tz
+        naive = _parse_ts("2026-04-12T17:23:27")
+        zulu = _parse_ts("2026-04-12T17:23:27Z")
+        self.assertEqual(
+            zulu, _dt(2026, 4, 12, 17, 23, 27, tzinfo=_tz.utc).timestamp())
+        self.assertEqual(naive, _dt(2026, 4, 12, 17, 23, 27).timestamp())
+        # The same instant written with a +02:00 offset must equal the Z form
+        # (the pre-fix parser stripped the offset and drifted by the local
+        # UTC offset).
+        self.assertEqual(_parse_ts("2026-04-12T19:23:27+02:00"), zulu)
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_transcript — malformed-record guards
+# ---------------------------------------------------------------------------
+class TestAggregateTranscriptGuards(unittest.TestCase):
+    """A record whose "message" is a *string* containing the substring
+    "usage" used to crash the stats aggregation with AttributeError
+    (str.get) — uncaught by the OSError/UnicodeDecodeError handler."""
+
+    def test_non_dict_message_and_usage_are_skipped(self):
+        import monitor
+        with tempfile.TemporaryDirectory() as td:
+            jl = pathlib.Path(td) / "sess.jsonl"
+            ts = "2026-04-12T17:23:27Z"
+            lines = [
+                json.dumps({"type": "assistant", "timestamp": ts,
+                            "message": "free text mentioning usage"}),
+                json.dumps({"type": "assistant", "timestamp": ts,
+                            "message": {"model": "m1", "usage": "not-a-dict"}}),
+                json.dumps({"type": "assistant", "timestamp": ts,
+                            "message": {"model": {"x": 1},
+                                        "usage": {"input_tokens": 1}}}),
+                json.dumps({"type": "assistant", "timestamp": ts,
+                            "message": {"model": "m1",
+                                        "usage": {"input_tokens": 5,
+                                                  "output_tokens": 7}}}),
+            ]
+            jl.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            st = jl.lstat()
+            models, active_days, daily_tokens, session_times = {}, set(), {}, {}
+            monitor._aggregate_transcript(
+                jl, st, "sess", False, 0,
+                models, active_days, daily_tokens, session_times)
+            self.assertEqual(list(models), ["m1"])
+            self.assertEqual(models["m1"]["input"], 5)
+            self.assertEqual(models["m1"]["calls"], 1)
 
 
 # ---------------------------------------------------------------------------
@@ -2135,6 +2179,14 @@ class TestLoadState(unittest.TestCase):
     def test_invalid_sid_returns_none(self):
         result = load_state("../evil")
         self.assertIsNone(result)
+
+    def test_reserved_sid_returns_none(self):
+        # FILE-IPC "Invalid SID Handling": reserved stems are internal files
+        # (release state / stats / pulse), never session snapshots.
+        for sid in ("rls", "stats", "pulse"):
+            p = pathlib.Path(self._tmp) / f"{sid}.json"
+            p.write_text(json.dumps({"session_id": sid}), encoding="utf-8")
+            self.assertIsNone(load_state(sid), sid)
 
     def test_missing_file_returns_none(self):
         result = load_state("nonExistentSid")
@@ -4395,7 +4447,7 @@ class TestAuditFixesV1130(unittest.TestCase):
     def test_window_buf_never_exceeds_rows(self):
         monitor._modal_scroll = 0
         big = [f"line{i}" for i in range(40)]
-        for rows in (2, 3, 4, 5, 10, 24):
+        for rows in (1, 2, 3, 4, 5, 10, 24):
             out = monitor._window_buf(list(big), rows)
             self.assertLessEqual(
                 len(out), rows,

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -264,6 +264,72 @@ class TestRunGitEnvWhitelist(unittest.TestCase):
             run_git(["status"], cwd=".", timeout=5)
         self.assertEqual(m.call_args[1]["env"].get("GIT_TERMINAL_PROMPT"), "0")
 
+    def test_git_binary_resolved_to_absolute_path(self):
+        # SEC (PATH injection): argv[0] must be the import-time absolute
+        # resolution, not a bare "git" re-resolved per call (on Windows
+        # CreateProcess would even consult the CWD).
+        from unittest.mock import patch as _patch, MagicMock
+        if shared._GIT_BIN is None:
+            self.skipTest("git not installed")
+        with _patch("subprocess.run",
+                    return_value=MagicMock(returncode=0, stdout="", stderr="")) as m:
+            shared.run_git(["status"], cwd=".", timeout=5)
+        argv0 = m.call_args[0][0][0]
+        self.assertEqual(argv0, shared._GIT_BIN)
+        self.assertTrue(os.path.isabs(argv0))
+
+
+# ---------------------------------------------------------------------------
+# Security: self-update origin pinning
+# ---------------------------------------------------------------------------
+class TestVerifyOriginRemote(unittest.TestCase):
+
+    @staticmethod
+    def _cp(rc=0, out=""):
+        import subprocess as _sp
+        return _sp.CompletedProcess(["git"], rc, stdout=out, stderr="")
+
+    def test_canonical_urls_pass(self):
+        for url in ("https://github.com/iM3SK/cc-aio-mon",
+                    "https://github.com/iM3SK/cc-aio-mon.git",
+                    "git@github.com:iM3SK/cc-aio-mon.git",
+                    "ssh://git@github.com/iM3SK/cc-aio-mon"):
+            with patch("shared.run_git", return_value=self._cp(out=url + "\n")):
+                self.assertIsNone(shared.verify_origin_remote(pathlib.Path(".")), url)
+
+    def test_foreign_url_rejected(self):
+        with patch("shared.run_git",
+                   return_value=self._cp(out="https://github.com/evil/cc-aio-mon\n")):
+            problem = shared.verify_origin_remote(pathlib.Path("."))
+            self.assertIsNotNone(problem)
+            self.assertIn("evil", problem)
+
+    def test_missing_origin_rejected(self):
+        with patch("shared.run_git", return_value=self._cp(rc=2)):
+            self.assertIsNotNone(shared.verify_origin_remote(pathlib.Path(".")))
+
+    def test_override_env_exact_match(self):
+        url = "https://example.com/fork/cc-aio-mon.git"
+        with patch("shared.run_git", return_value=self._cp(out=url + "\n")):
+            with patch.dict(os.environ, {"CC_AIO_MON_REMOTE": url}):
+                self.assertIsNone(shared.verify_origin_remote(pathlib.Path(".")))
+            with patch.dict(os.environ,
+                            {"CC_AIO_MON_REMOTE": "https://example.com/other.git"}):
+                self.assertIsNotNone(shared.verify_origin_remote(pathlib.Path(".")))
+
+
+# ---------------------------------------------------------------------------
+# lock_file_handle / unlock_file_handle (statusline history append/trim lock)
+# ---------------------------------------------------------------------------
+class TestLockFileHandle(unittest.TestCase):
+
+    def test_lock_roundtrip(self):
+        with tempfile.TemporaryDirectory() as td:
+            lockf = pathlib.Path(td) / "x.jsonl.lock"
+            with open(lockf, "a", encoding="utf-8") as fh:
+                self.assertTrue(shared.lock_file_handle(fh))
+                shared.unlock_file_handle(fh)  # must not raise
+
 
 # ---------------------------------------------------------------------------
 # Security: pre-push hook scans new branch tips
@@ -661,10 +727,14 @@ class TestEnvPct(unittest.TestCase):
             self.assertEqual(shared._env_pct("CLAUDE_STATUS_TESTVAR", 50.0), 50.0)
 
     def test_missing_uses_default(self):
-        # patch.dict with clear=False + setdefault-style pop won't run reliably;
-        # set then remove so we know the env var is absent.
-        os.environ.pop("CLAUDE_STATUS_TESTVAR", None)
-        self.assertEqual(shared._env_pct("CLAUDE_STATUS_TESTVAR", 50.0), 50.0)
+        # Remove the var for the assertion, then restore whatever was there
+        # so test order can't leak state between tests.
+        prev = os.environ.pop("CLAUDE_STATUS_TESTVAR", None)
+        try:
+            self.assertEqual(shared._env_pct("CLAUDE_STATUS_TESTVAR", 50.0), 50.0)
+        finally:
+            if prev is not None:
+                os.environ["CLAUDE_STATUS_TESTVAR"] = prev
 
     def test_integer_string_parsed(self):
         with patch.dict(os.environ, {"CLAUDE_STATUS_TESTVAR": "80"}):

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -402,6 +402,25 @@ class TestTrimHistory(unittest.TestCase):
         self.assertEqual(len(result), HISTORY_TRIM_TO)
         p.unlink()
 
+    def test_trim_drops_malformed_lines(self):
+        # FILE-IPC "Trim Policy": lines that fail json.loads() are dropped
+        # during trim so a torn write cannot survive rewrites forever.
+        import json, tempfile, pathlib
+        from statusline import _trim_history, HISTORY_TRIM_TO
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl",
+                                          delete=False, encoding="utf-8")
+        lines = [f'{{"i": {i}}}' for i in range(HISTORY_TRIM_TO + 10)]
+        lines[-5] = '{"torn": '  # malformed line inside the kept tail
+        tmp.write("\n".join(lines) + "\n")
+        tmp.close()
+        p = pathlib.Path(tmp.name)
+        _trim_history(p)
+        result = p.read_text(encoding="utf-8").strip().splitlines()
+        self.assertEqual(len(result), HISTORY_TRIM_TO - 1)
+        for ln in result:
+            json.loads(ln)  # every surviving line is valid JSON
+        p.unlink()
+
 
 # ---------------------------------------------------------------------------
 # _load_history_for_rates

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -428,14 +428,30 @@ class TestApplyUpdateAction(unittest.TestCase):
             os.environ["CC_AIO_MON_NO_UPDATE_CHECK"] = self._orig_env
 
     def test_zero_rc_with_valid_syntax_marks_complete(self):
-        # Test the synchronous worker directly (not the thread-spawning wrapper)
-        with patch("monitor._git_cmd", return_value=(0, "ok", "")):
-            with patch("pathlib.Path.exists", return_value=True):
-                with patch("pathlib.Path.read_text", return_value="# valid python\nx = 1\n"):
-                    _apply_update_worker()
+        # Test the synchronous worker directly (not the thread-spawning wrapper).
+        # _update_checks is patched clean — the worker now blocks on warnings.
+        with patch("monitor._update_checks", return_value=[]):
+            with patch("monitor._git_cmd", return_value=(0, "ok", "")):
+                with patch("pathlib.Path.exists", return_value=True):
+                    with patch("pathlib.Path.read_text", return_value="# valid python\nx = 1\n"):
+                        _apply_update_worker()
 
         import monitor
         self.assertIn("complete", monitor._update_result)
+
+    def test_warnings_block_apply(self):
+        # SEC: the worker re-runs the CLI-equivalent safety checks itself —
+        # any warning must block the pull entirely (the modal is advisory).
+        import monitor
+
+        def _no_git(args, timeout=15):
+            raise AssertionError(f"git must not run when checks warn: {args}")
+
+        with patch("monitor._update_checks",
+                   return_value=["Uncommitted changes in working tree"]):
+            with patch("monitor._git_cmd", side_effect=_no_git):
+                _apply_update_worker()
+        self.assertIn("Update blocked", monitor._update_result)
 
     def test_syntax_check_uses_safe_read(self):
         # After the shared.check_syntax_after_pull extraction, the loop +
@@ -450,17 +466,19 @@ class TestApplyUpdateAction(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             repo_root = pathlib.Path(td)
             (repo_root / "monitor.py").write_text("# stub")
-            with patch("monitor._git_cmd", return_value=(0, "ok", "")):
-                with patch.object(shared, "PY_FILES", ("monitor.py",)):
-                    with patch.object(monitor, "_REPO_ROOT", repo_root):
-                        with patch("shared.safe_read", return_value=None) as mock_safe_read:
-                            _apply_update_worker()
+            with patch("monitor._update_checks", return_value=[]):
+                with patch("monitor._git_cmd", return_value=(0, "ok", "")):
+                    with patch.object(shared, "PY_FILES", ("monitor.py",)):
+                        with patch.object(monitor, "_REPO_ROOT", repo_root):
+                            with patch("shared.safe_read", return_value=None) as mock_safe_read:
+                                _apply_update_worker()
             mock_safe_read.assert_called_once()
             self.assertIn("syntax errors", monitor._update_result)
 
     def test_nonzero_rc_marks_failed_with_stderr(self):
-        with patch("monitor._git_cmd", return_value=(1, "", "conflict")):
-            _apply_update_worker()
+        with patch("monitor._update_checks", return_value=[]):
+            with patch("monitor._git_cmd", return_value=(1, "", "conflict")):
+                _apply_update_worker()
 
         import monitor
         self.assertIn("failed", monitor._update_result)

--- a/update.py
+++ b/update.py
@@ -19,7 +19,7 @@ from typing import List, Optional, Tuple
 from shared import (
     VERSION_RE, MAX_FILE_SIZE, _sanitize, run_git as _shared_run_git,
     ensure_utf8_stdout, extract_changelog_entry, PY_FILES, safe_read,
-    check_syntax_after_pull, parse_ahead_behind,
+    check_syntax_after_pull, parse_ahead_behind, verify_origin_remote,
     DATA_DIR, ensure_data_dir, acquire_singleton_lock,
 )
 
@@ -29,18 +29,30 @@ if sys.platform == "win32":
 
 # ---------- ANSI colors (Windows VT enable) ----------
 def _enable_vt_on_windows():
-    if sys.platform == "win32":
-        try:
-            h = ctypes.windll.kernel32.GetStdHandle(-11)
-            ctypes.windll.kernel32.SetConsoleMode(h, 7)
-        except Exception:
-            pass
+    """Best-effort VT enable. Returns True when ANSI escapes are safe to emit."""
+    if sys.platform != "win32":
+        return True
+    try:
+        kernel32 = ctypes.windll.kernel32
+        # HANDLE is pointer-sized — without restype, ctypes truncates the
+        # return value to c_int on 64-bit Windows and SetConsoleMode gets a
+        # corrupted handle (same class of fix as statusline's CONOUT$ branch).
+        kernel32.GetStdHandle.restype = ctypes.c_void_p
+        kernel32.SetConsoleMode.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+        h = kernel32.GetStdHandle(-11)
+        if h is None or h == ctypes.c_void_p(-1).value:
+            return False
+        return bool(kernel32.SetConsoleMode(h, 7))
+    except Exception:
+        return False
 
 
 def _init_terminal():
-    """Set up UTF-8 stdout and VT processing. Called from main() only."""
+    """Set up UTF-8 stdout and VT processing. Called from main() only.
+    Returns True when ANSI escapes are safe to emit (gates the color palette
+    so a failed VT enable doesn't spray raw escapes into the console)."""
     ensure_utf8_stdout()
-    _enable_vt_on_windows()
+    return _enable_vt_on_windows()
 
 
 # Colors are set lazily after _init_terminal() — defaults for import safety.
@@ -188,12 +200,12 @@ def apply_update():
             note(f"Lock file: {DATA_DIR / 'monitor.lock'} (inspect for PID)")
             sys.exit(1)
     else:
-        _lock_handle = None  # data dir unusable — proceed without lock (best effort)
-        print(
-            "Warning: lock dir unavailable; proceeding without singleton guard. "
-            "If monitor.py is running, file replacement may race.",
-            file=sys.stderr,
-        )
+        # FILE-IPC contract: --apply replaces the runtime files and must hold
+        # the singleton lock — racing a live monitor.py on file replacement
+        # can leave a half-updated install. Fail fast instead of best-effort.
+        err("Data directory unusable — cannot take the singleton lock.")
+        note(f"Data dir: {DATA_DIR} (check permissions/ownership)")
+        sys.exit(1)
 
     # Rollback point — created before pull so user can revert via `git reset --hard <tag>`
     ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -249,8 +261,8 @@ def main():
             signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         except (AttributeError, ValueError):
             pass
-    _init_terminal()
-    if sys.stdout.isatty():
+    vt_ok = _init_terminal()
+    if sys.stdout.isatty() and vt_ok:
         GRN = "\033[32m"; YEL = "\033[33m"; RED = "\033[31m"
         CYN = "\033[36m"; DIM = "\033[2m"; R = "\033[0m"
 
@@ -276,6 +288,15 @@ def main():
     check_clean()
 
     hdr("Remote check")
+    # SEC: pin self-update to the canonical repo — a rewritten origin must not
+    # be able to feed the updater foreign code.
+    remote_problem = verify_origin_remote(REPO_ROOT)
+    if remote_problem:
+        err(f"Origin check failed: {remote_problem}")
+        note("Self-update pulls only from the canonical repo. "
+             "Forks: set CC_AIO_MON_REMOTE to your remote URL.")
+        sys.exit(1)
+    ok("Origin: canonical remote verified")
     fetch_remote()
 
     hdr("Version comparison")


### PR DESCRIPTION
Cross-model review remediation of v1.13.0 — every finding verified against the code before fixing. Full detail in the CHANGELOG v1.14.0 entry.

**Security:** self-update origin pinning (`shared.verify_origin_remote` + `CC_AIO_MON_REMOTE` fork override), TUI apply re-runs CLI guards and blocks on warnings, absolute git argv (PATH/CWD injection), TOCTOU fstat guard in `_aggregate_session_cost`, junction-safe subagents scan.

**Bug fixes:** aggregator type guards (string `message` crash), TZ-aware `_parse_ts`, history append/trim lock sidecar + malformed-line drop, fail-fast without singleton lock, reserved-SID gate in `load_state`, ctypes HANDLE restype fixes (monitor + update), `_window_buf` rows=1 off-by-one.

**Also:** Fable 5 + Opus 4.8 pricing entries, CC_MON_* gauge-ceiling env vars documented, FILE-IPC contract corrections (pulse.jsonl persistence-only, schema gate, `model.id`).

**Tests:** 678 → 688, suite green; `scripts/release.sh 1.14.0` pre-flight passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)