### PR TITLE
docs: zladenie dokumentácie s kódom v1.15.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
    `unittest discover tests/`, so the `py tests.py` invocation continues to work
    unchanged.
 
-   **Baseline: 710 tests passing (3 skipped on platforms missing optional artifacts).**
+   **Baseline: 710 tests passing (skip count is platform-dependent — 0 on a standard Linux/macOS box with git; a few skip on Windows or where git/symlinks/SIGPIPE are unavailable).**
    Contributions must not reduce the passing count without explanation. If you add
    tests, put them in the file that matches the module under test — helpers go in
    `test_shared.py`, TUI logic in `test_monitor.py`, and so on.
@@ -45,7 +45,7 @@
 ## What to keep in sync
 
 - **`shared.py` is the single source of truth** — all cross-file constants, helpers, ANSI palette, and regexes live there. Never duplicate a literal or a helper in `statusline.py` / `monitor.py` / `pulse.py` / `update.py`. The shared surface includes:
-  - **Constants:** `VERSION`, `PY_FILES`, `_SID_RE`, `_ANSI_RE`, `MIN_EPOCH`, `MAX_FILE_SIZE`, `HISTORY_READ_MAX`, `HISTORY_AGGREGATE_MAX`, `TRANSCRIPT_MAX_BYTES`, `DATA_DIR`, `DATA_DIR_NAME`, `VERSION_RE`, `RESERVED_SIDS`, `WARN_PCT`, `CRIT_PCT`.
+  - **Constants:** `VERSION`, `PY_FILES`, `_SID_RE`, `_ANSI_RE`, `MIN_EPOCH`, `MAX_FILE_SIZE`, `HISTORY_READ_MAX`, `HISTORY_AGGREGATE_MAX`, `HISTORY_RATE_SAMPLES`, `TRANSCRIPT_MAX_BYTES`, `DATA_DIR`, `DATA_DIR_NAME`, `VERSION_RE`, `RESERVED_SIDS`, `WARN_PCT`, `CRIT_PCT`.
   - **ANSI palette:** `E`, `R`, `B`, `C_RED`, `C_GRN`, `C_YEL`, `C_ORN`, `C_CYN`, `C_WHT`, `C_DIM`.
   - **Helpers:** `_num`, `_sanitize`, `safe_read`, `f_tok`, `f_cost`, `f_dur`, `f_cd`, `char_width`, `is_safe_dir`, `ensure_data_dir`, `ensure_utf8_stdout`, `load_history`, `strip_context_suffix`, `compact_context_suffix`, `badge_context_suffix`, `extract_changelog_entry`, `run_git`, `verify_origin_remote`, `calc_rates`, `atomic_write_text`, `acquire_singleton_lock`, `lock_file_handle`, `unlock_file_handle`, `check_syntax_after_pull`, `parse_ahead_behind`, `rotate_crash_log`.
   - If you add a helper or constant that is (or could be) used by more than one module, put it in `shared.py` from day one.
@@ -74,7 +74,7 @@ For anything non-trivial — new features, behavior changes, refactors beyond lo
 ## See also
 
 - [README.md](README.md) — feature overview, metrics, keyboard shortcuts, architecture
-- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — module map, data-flow diagram, and "where to look for X" guide; read this before opening `monitor.py` (~3 600 LOC)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — module map, data-flow diagram, and "where to look for X" guide; read this before opening `monitor.py` (~3 700 LOC)
 - [docs/FILE-IPC-CONTRACT.md](docs/FILE-IPC-CONTRACT.md) — canonical field schema for the statusline→monitor JSON contract and JSONL history entries
 - [CHANGELOG.md](CHANGELOG.md) — release history
 - [.github/SECURITY.md](.github/SECURITY.md) — security model and vulnerability reporting

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ export CLAUDE_STATUS_CRIT=90
 ## Known Limitations
 
 - **Delayed refresh after context compaction** — when Claude Code compacts the context window, the dashboard continues showing the pre-compaction CTX value until Claude Code emits the next statusline event (typically the next assistant message). This is a Claude Code protocol limitation — `statusline.py` is only invoked on assistant messages, permission mode changes, or vim mode toggles. There is no external API to trigger a refresh on demand.
-- **Pricing drift** — model prices are hardcoded snapshots of Anthropic's published rates at release time. If Anthropic adjusts pricing, cost breakdown numbers drift until the next release. Cost breakdown stores explicit per-model per-1M-token rates; cache-read rates are roughly 0.1× and cache-write roughly 1.25× the model's input rate. Current priced families: Opus (4.1 / 4.5 / 4.6 / 4.7 / 4.8), Sonnet (4.5 / 4.6), Haiku (3.5 / 4.5).
+- **Pricing drift** — model prices are hardcoded snapshots of Anthropic's published rates at release time. If Anthropic adjusts pricing, cost breakdown numbers drift until the next release. Cost breakdown stores explicit per-model per-1M-token rates; cache-read rates are roughly 0.1× and cache-write roughly 1.25× the model's input rate. Current priced families: Fable 5, Mythos 5, Opus (4.1 / 4.5 / 4.6 / 4.7 / 4.8), Sonnet (4.5 / 4.6), Haiku (3.5 / 4.5).
 - **Local timezone everywhere** — all timestamps (header clock, daily aggregation, rollback tags like `pre-update-YYYYMMDD-HHMMSS`, pulse JSONL entries) use the machine's local timezone, not UTC. If you ship temp-dir logs to a maintainer in a different zone, clock labels will not line up — report the date plus your TZ offset when filing an issue.
 
 ## Troubleshooting

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # CC AIO MON — Architecture Overview
 
-> v1.12.4 · Target reader: new contributor who just cloned the repo.
+> v1.15.0 · Target reader: new contributor who just cloned the repo.
 > Goal: understand "where is what and how do things relate" in ~10 minutes.
 > For the full feature reference see [README.md](../README.md).
 > For the IPC field schema see [FILE-IPC-CONTRACT.md](FILE-IPC-CONTRACT.md).
@@ -66,7 +66,7 @@ by `build_line()` when the terminal is too narrow. On Windows, terminal width
 is queried via `CONOUT$` because Claude Code runs this script with all file
 descriptors piped (`_get_terminal_width`).
 
-**monitor.py** — Entry point 2 (interactive TUI). ~3 600 LOC. Owns the event
+**monitor.py** — Entry point 2 (interactive TUI). ~3 700 LOC. Owns the event
 loop, all `render_*` functions, the session picker, and the daemon worker
 threads (see Section 5). The crash logger (`_install_crash_logger`) writes
 uncaught exceptions to `monitor-crash.log` because the alt-screen buffer would
@@ -182,7 +182,7 @@ thread.
   release-check thread runs at a time (acquired non-blocking in
   `_maybe_trigger_rls_check`, released in `_rls_check_worker`).
 - `_rls_data_lock` (`threading.Lock`) — coherence for the three-field
-  `_rls_cache` dict (`version`, `status`, `checked_at`) accessed by both the
+  `_rls_cache` dict (`t`, `status`, `remote_ver`) accessed by both the
   daemon writer and the main render thread.
 - `_update_lock` (`threading.Lock`) — protects `_update_result` (the shared
   state between `_apply_update_worker` and `render_update_modal`).
@@ -331,7 +331,7 @@ for `git rev-list --left-right --count` output in both files.
 | Goal | Start here |
 |---|---|
 | Change how burn rate or context rate is computed | `shared.calc_rates()` — reads last `HISTORY_RATE_SAMPLES` JSONL history entries |
-| Change hardcoded model pricing | `monitor._aggregate_session_cost()` and the per-model rate dicts above it |
+| Change hardcoded model pricing | `monitor._MODELS` dict (single source of truth, keyed by model ID) read via `_get_pricing()`; `_model_base()` normalizes the ID (strips `[...]` + `-YYYYMMDD`), `_DEFAULT_PRICING` is the Sonnet-tier fallback, `speed="fast"` selects the `pricing_fast` rates |
 | Add a field to the IPC snapshot | `statusline.write_shared_state()` → add field to `snapshot`/`entry` dict → bump `shared.SCHEMA_VERSION` (and extend `pulse.PulseSnapshot` if it is a pulse field) |
 | Add a new TUI modal | `monitor.render_frame()` dispatches to `render_*` functions; add a new `render_xyz()`, end it with `_window_buf(buf, rows)` so it scrolls (pinned header + scroll-position hint), and wire a key in the event loop |
 | Add a statusline segment | Add a `seg_xyz()` function in `statusline.py` (see `seg_model`, `seg_ctx`, etc.) and insert it into the `all_segs` list in `build_line()` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -62,7 +62,7 @@ If you add a new env var, add it here in the same commit.
 
 - **Type:** float ($/min)
 - **Default:** `10.0`
-- **Read by:** `monitor.py` (`_env_float` → `BRN_MAX`, `monitor.py:731`)
+- **Read by:** `monitor.py` (`_env_float` → `BRN_MAX`)
 - **Effect:** ceiling of the `BRN` progress bar and the `BRN OVER TIME`
   axis. Raise if the bar pins (e.g. 24/7 Opus API workloads).
 
@@ -70,14 +70,14 @@ If you add a new env var, add it here in the same commit.
 
 - **Type:** float (%/min)
 - **Default:** `10.0`
-- **Read by:** `monitor.py` (`_env_float` → `CTR_MAX`, `monitor.py:732`)
+- **Read by:** `monitor.py` (`_env_float` → `CTR_MAX`)
 - **Effect:** ceiling of the `CTR` (context consumption rate) bar.
 
 ### `CC_MON_CST_MAX`
 
 - **Type:** float ($)
 - **Default:** `1000.0`
-- **Read by:** `monitor.py` (`_env_float` → `CST_MAX`, `monitor.py:733`)
+- **Read by:** `monitor.py` (`_env_float` → `CST_MAX`)
 - **Effect:** ceiling of the `CST` (session cost) bar. Raise for
   long-running API sessions.
 
@@ -171,9 +171,9 @@ have a documented diagnostic anchor.
 - **Type:** flag (`"1"` enables UTF-8 mode)
 - **Default:** unset (Python uses the locale codec for stdin/stdout)
 - **Recommended:** `1` on non-UTF-8 Windows locales (SK, CZ, PL, …) when
-  invoking `statusline.py` or `monitor.py` directly. The shipped
-  `ccaiomon.bat` sets this; users on bare `python statusline.py` should
-  consider the wrapper instead.
+  invoking `statusline.py` or `monitor.py` directly. Set it in the shell
+  or launcher that runs the script (e.g. prefix the Claude Code statusline
+  command, or `set PYTHONUTF8=1` in your own wrapper).
 - **Why:** Claude Code emits its statusline JSON as UTF-8 bytes. Without
   `PYTHONUTF8=1` (or the byte-level `sys.stdin.buffer.read()` path added
   in NEW-002), Python on CP1250 / CP1252 Windows locales would
@@ -188,7 +188,8 @@ have a documented diagnostic anchor.
 - **Default:** unset
 - **Recommended:** `utf-8` on non-UTF-8 Windows locales — covers the
   cases `PYTHONUTF8=1` does not (notably some embedded Python launchers
-  and older 3.8 setups). The shipped `ccaiomon.bat` sets this too.
+  and older 3.8 setups). Set it alongside `PYTHONUTF8` in the same shell
+  or launcher.
 - **Effect:** forces `sys.stdout.encoding` to a known value;
   `shared.ensure_utf8_stdout()` is the runtime safety net if neither env
   var is set.

--- a/docs/FILE-IPC-CONTRACT.md
+++ b/docs/FILE-IPC-CONTRACT.md
@@ -1,8 +1,8 @@
-# FILE-IPC CONTRACT: cc-aio-mon v1.12.4
+# FILE-IPC CONTRACT: cc-aio-mon v1.15.0
 
 **Status**: Active  
-**Version**: 1.12.4 (`SCHEMA_VERSION` = 1)  
-**Last Updated**: 2026-05-30  
+**Version**: 1.15.0 (`SCHEMA_VERSION` = 1)  
+**Last Updated**: 2026-06-14  
 **Source Truth**: `shared.py`, `statusline.py`, `monitor.py`, `pulse.py`
 
 See also: [ARCHITECTURE.md](ARCHITECTURE.md) for module overview, [RELEASE.md](RELEASE.md) for release process.
@@ -153,7 +153,7 @@ pathlib.Path(fd.name).replace(target)  # atomic on all platforms
 
 ```python
 def load_state(sid):
-    if not _SID_RE.match(str(sid)):
+    if sid in RESERVED_SIDS or not _SID_RE.match(str(sid)):
         return None
     if not is_safe_dir(DATA_DIR):
         return None
@@ -325,7 +325,7 @@ Each line is a JSON object with these fields:
 
 **Example Line**:
 ```json
-{"session_id":"default","model":{"display_name":"Opus 4.7","id":"claude-opus-4-1-20250805"},"context_window":{"context_window_size":200000,"used_percentage":45.5},"cost":{"total_cost_usd":0.15},"rate_limits":{"five_hour":{"used_percentage":10,"resets_at":1716379200},"seven_day":{"used_percentage":5,"resets_at":1716639600}},"_schema_version":1,"t":1716292800.123}
+{"session_id":"default","model":{"display_name":"Opus 4.8","id":"claude-opus-4-8"},"context_window":{"context_window_size":200000,"used_percentage":45.5},"cost":{"total_cost_usd":0.15},"rate_limits":{"five_hour":{"used_percentage":10,"resets_at":1716379200},"seven_day":{"used_percentage":5,"resets_at":1716639600}},"_schema_version":1,"t":1716292800.123}
 ```
 
 ### File Size Management
@@ -794,6 +794,6 @@ All IPC is best-effort. No exceptions are raised to the user—errors are logged
 
 ---
 
-**Document Version**: 1.12.0  
-**Last Verified**: 2026-05-22  
+**Document Version**: 1.15.0  
+**Last Verified**: 2026-06-14  
 **Status**: Production

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -68,12 +68,12 @@ Work through these in order before creating any tag.
 
 - [ ] **CHANGELOG entry drafted** (see Section 3 for exact format).
   Write the entry for the new version at the top of `CHANGELOG.md`, above the
-  current `## v1.12.4` block. Do not push yet.
+  current top-most `## vX.Y.Z` block. Do not push yet.
 
 - [ ] **VERSION constant bumped in `shared.py` only.**
   The constant lives at `shared.py`:
   ```python
-  VERSION = "1.12.4"
+  VERSION = "X.Y.Z"
   ```
   Change this string to the new version. Do not touch `monitor.py`,
   `pulse.py`, or `update.py` for the version — all three import from
@@ -86,6 +86,23 @@ Work through these in order before creating any tag.
 - [ ] **Re-run tests after the VERSION and CHANGELOG edits.**
   Confirm the count is still correct and no test imports a hard-coded version
   string that needs updating.
+
+- [ ] **Documentation in sync with the code.** Several docs hard-code values
+  that drift between releases — verify each against the code before tagging,
+  and when a code PR changes any of them, fix the doc in the **same PR** (this
+  is what left v1.15.0's docs stale until a follow-up audit caught it):
+  - **Version markers** → bump to the new `vX.Y.Z`: `docs/ARCHITECTURE.md`
+    header, `docs/FILE-IPC-CONTRACT.md` header **and** footer. (`shared.VERSION`
+    is the source of truth; these are mirrors that must be updated by hand.)
+  - **Test-count baseline** → match `py tests.py`: `CONTRIBUTING.md` and the
+    "Current baseline" line in this file (Section 2).
+  - **`monitor.py` LOC** → `wc -l monitor.py`: `docs/ARCHITECTURE.md` and
+    `CONTRIBUTING.md`.
+  - **Model table** → when `monitor._MODELS` gains or loses a *priced* family,
+    update the "Current priced families" line in `README.md` (and any model-ID
+    examples in `docs/FILE-IPC-CONTRACT.md`).
+  - **Avoid hard-coded line numbers** in docs (`monitor.py:NNN`) — they rot on
+    every edit; reference the function/symbol name instead.
 
 ---
 


### PR DESCRIPTION
Audit správnosti všetkých docs proti kódu po PR #70/v1.15.0. Opravené: ARCHITECTURE pricing pointer (_MODELS/_get_pricing) + _rls_cache polia + LOC; README +Fable 5/Mythos 5; FILE-IPC verzné markery v1.15.0 + load_state snippet; CONFIGURATION odstránené stale čísla riadkov + neexistujúci ccaiomon.bat; RELEASE generické vX.Y.Z; CONTRIBUTING skip-count + HISTORY_RATE_SAMPLES + LOC. Žiadna zmena kódu, bez bumpu verzie, tests 710/710 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)