### PR TITLE
fix(monitor): 5HL/7DL account-wide čítanie + release v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v1.15.1 — 2026-06-14
+
+**Bug fixes:**
+- **Rate limits read account-wide.** The 5HL/7DL panel now sources `rate_limits`
+  from the freshest snapshot across all sessions instead of only the viewed
+  session. 5H/7D limits are per-account but each session writes them solely into
+  its own snapshot, and an idle session's snapshot freezes — so switching between
+  concurrent sessions (or watching one that went idle) surfaced stale, pre-reset
+  values that appeared to jump around. `monitor.cached_freshest_rate_limits()`
+  picks the max-`mtime` snapshot (main-thread, 2 s TTL, same schema gate as
+  `load_state`); the event loop injects it via `render_frame(..., rate_limits=)`.
+  Known limitation: snapshots carry no account identifier, so with multiple
+  accounts running at once another account's limits may show; single-account is
+  exact.
+
+**Tests:** 715 passing (+5).
+
 ## v1.15.0 — 2026-06-14
 
 **Features — pricing coverage:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
    `unittest discover tests/`, so the `py tests.py` invocation continues to work
    unchanged.
 
-   **Baseline: 710 tests passing (skip count is platform-dependent — 0 on a standard Linux/macOS box with git; a few skip on Windows or where git/symlinks/SIGPIPE are unavailable).**
+   **Baseline: 715 tests passing (skip count is platform-dependent — 0 on a standard Linux/macOS box with git; a few skip on Windows or where git/symlinks/SIGPIPE are unavailable).**
    Contributions must not reduce the passing count without explanation. If you add
    tests, put them in the file that matches the module under test — helpers go in
    `test_shared.py`, TUI logic in `test_monitor.py`, and so on.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # CC AIO MON — Architecture Overview
 
-> v1.15.0 · Target reader: new contributor who just cloned the repo.
+> v1.15.1 · Target reader: new contributor who just cloned the repo.
 > Goal: understand "where is what and how do things relate" in ~10 minutes.
 > For the full feature reference see [README.md](../README.md).
 > For the IPC field schema see [FILE-IPC-CONTRACT.md](FILE-IPC-CONTRACT.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -338,3 +338,4 @@ for `git rev-list --left-right --count` output in both files.
 | Change the Anthropic Pulse scoring weights | `pulse.py` constants `_W_INDICATOR`, `_W_INCIDENTS`, `_W_LATENCY` and `_INDICATOR_SCORE` / `_IMPACT_DEDUCT` dicts |
 | Add a new Python file to the project | Append the filename to `shared.PY_FILES` — this propagates to the post-update syntax check and the compile-check in the test suite |
 | Understand the session file format | `statusline.py:write_shared_state()` writes it; `monitor.py:load_state()` reads it; field names mirror the Claude Code statusline JSON protocol keys |
+| Change how 5HL/7DL rate limits are sourced | `monitor.cached_freshest_rate_limits()` — account-wide read from the freshest snapshot across all sessions (per-account limits, idle snapshots freeze); injected via `render_frame(..., rate_limits=...)`. See FILE-IPC-CONTRACT "Rate Limits — account-wide read semantics" |

--- a/docs/FILE-IPC-CONTRACT.md
+++ b/docs/FILE-IPC-CONTRACT.md
@@ -1,7 +1,7 @@
-# FILE-IPC CONTRACT: cc-aio-mon v1.15.0
+# FILE-IPC CONTRACT: cc-aio-mon v1.15.1
 
 **Status**: Active  
-**Version**: 1.15.0 (`SCHEMA_VERSION` = 1)  
+**Version**: 1.15.1 (`SCHEMA_VERSION` = 1)  
 **Last Updated**: 2026-06-14  
 **Source Truth**: `shared.py`, `statusline.py`, `monitor.py`, `pulse.py`
 
@@ -809,6 +809,6 @@ All IPC is best-effort. No exceptions are raised to the user—errors are logged
 
 ---
 
-**Document Version**: 1.15.0  
+**Document Version**: 1.15.1  
 **Last Verified**: 2026-06-14  
 **Status**: Production

--- a/docs/FILE-IPC-CONTRACT.md
+++ b/docs/FILE-IPC-CONTRACT.md
@@ -206,6 +206,21 @@ def load_state(sid):
 
 **Forward Compatibility**: Monitor uses `dict.get()` (never KeyError) so unknown fields in future snapshots are silently ignored.
 
+### Rate Limits — account-wide read semantics
+
+`rate_limits` (5H/7D) are **per-account** — shared across every session — yet each
+session's statusline writes them only into its own snapshot, and an idle session's
+snapshot freezes. Reading them from a single session would surface stale/pre-reset
+values whenever another session was more recently active. The monitor therefore
+sources `rate_limits` from the **freshest snapshot across all sessions** (max
+`mtime`), via `monitor.cached_freshest_rate_limits()` (main-thread, 2 s TTL, same
+schema gate as `load_state`). `render_frame(..., rate_limits=<override>)` applies it;
+with no override the function falls back to the passed session's own field.
+
+**Caveat**: snapshots carry **no account identifier**, so with multiple accounts
+running concurrently this may surface another account's limits. Single-account
+(the common case) is exact.
+
 ### Schema Version
 
 **Current Value**: 1 (`shared.SCHEMA_VERSION`)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -62,7 +62,7 @@ Work through these in order before creating any tag.
   python3 tests.py     # macOS / Linux
   ```
   `tests.py` is a thin wrapper that runs `unittest discover tests/`
-  (`tests.py:main()`). Current baseline: **710 passing** (v1.15.0). The new
+  (`tests.py:main()`). Current baseline: **715 passing** (v1.15.1). The new
   release's count must be >= this number unless tests were intentionally
   removed (document the removal in CHANGELOG).
 

--- a/monitor.py
+++ b/monitor.py
@@ -1114,6 +1114,58 @@ def load_state(sid):
     return d
 
 
+# Account-wide rate limits — 5H/7D are PER-ACCOUNT (shared across all sessions),
+# but each session's statusline writes them only into its own snapshot, and an
+# idle session's snapshot freezes (statusline runs only when Claude Code emits a
+# status-line event for that session). Reading rate_limits from the currently
+# viewed session therefore shows stale/pre-reset values whenever a *different*
+# session was more recently active. Source the freshest snapshot (max mtime)
+# across all sessions instead — the only account-correct value. CAVEAT: snapshots
+# carry no account identifier, so with multiple accounts running concurrently this
+# may surface another account's limits; single-account (the common case) is exact.
+_rl_fresh_cache = {"t": -1.0, "rl": None}  # main-thread only; mirrors cached_list_sessions
+
+
+def cached_freshest_rate_limits(fallback, ttl=2.0):
+    """Return rate_limits from the most recently written session snapshot.
+
+    Non-blocking main-thread scan with a TTL (the render loop runs at ~20Hz; a
+    per-frame DATA_DIR scan would be wasteful). Falls back to the caller's own
+    rate_limits when no snapshot carries usable limits (empty dir / tests)."""
+    now = time.monotonic()
+    if now - _rl_fresh_cache["t"] < ttl:
+        rl = _rl_fresh_cache["rl"]
+        return rl if rl is not None else fallback
+    best_mt = -1.0
+    best_rl = None
+    if DATA_DIR.exists() and is_safe_dir(DATA_DIR):
+        for f in DATA_DIR.glob("*.json"):
+            sid = f.stem
+            if sid in RESERVED_SIDS or not _SID_RE.match(sid):
+                continue
+            try:
+                mt = f.stat().st_mtime
+                if mt <= best_mt:
+                    continue  # cannot beat the current best — skip the read
+                raw = safe_read(f, MAX_FILE_SIZE)
+                if raw is None:
+                    continue
+                d = json.loads(raw.decode("utf-8"))
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(d, dict):
+                continue
+            sv = d.get("_schema_version")
+            if isinstance(sv, int) and sv > SCHEMA_VERSION:
+                continue  # newer-build snapshot — same gate as load_state
+            rl = d.get("rate_limits")
+            if rl:
+                best_mt = mt
+                best_rl = rl
+    _rl_fresh_cache.update({"t": now, "rl": best_rl})
+    return best_rl if best_rl is not None else fallback
+
+
 # Thin wrapper — shared.load_history is the single source of truth (v1.10.5+).
 # Passes monitor.DATA_DIR explicitly so tests that monkey-patch it still hit the fixture.
 def load_history(sid, n=HISTORY_RATE_SAMPLES):
@@ -1276,7 +1328,7 @@ def _apply_scroll(off, k, rows):
 # ---------------------------------------------------------------------------
 # Render — main dashboard
 # ---------------------------------------------------------------------------
-def render_frame(data, hist, cols, rows, show_legend=False, show_menu=False, show_cost=False, stale=False, show_agents=False, agents_active_only=False):
+def render_frame(data, hist, cols, rows, show_legend=False, show_menu=False, show_cost=False, stale=False, show_agents=False, agents_active_only=False, rate_limits=None):
     if show_menu:
         return render_menu(cols, rows)
     if show_cost:
@@ -1300,7 +1352,10 @@ def render_frame(data, hist, cols, rows, show_legend=False, show_menu=False, sho
     ctx_total = _num(cw.get("context_window_size"), 0)
     usage = cw.get("current_usage") or {}
 
-    rl = data.get("rate_limits")
+    # rate_limits override: the event loop passes the account-wide freshest value
+    # (see cached_freshest_rate_limits). None → fall back to this session's own
+    # snapshot field, preserving behaviour for direct/test callers.
+    rl = rate_limits if rate_limits is not None else data.get("rate_limits")
     cost_d = data.get("cost") or {}
     usd = _num(cost_d.get("total_cost_usd"))
     dur = _num(cost_d.get("total_duration_ms"))
@@ -3672,6 +3727,7 @@ def main():
                         last_data, last_hist, cols, rows,
                         show_legend, show_menu, show_cost, stale=is_stale,
                         show_agents=show_agents, agents_active_only=agents_active_only,
+                        rate_limits=cached_freshest_rate_limits(last_data.get("rate_limits")),
                     ),
                     cols,
                 )

--- a/shared.py
+++ b/shared.py
@@ -53,7 +53,7 @@ DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.15.0"
+VERSION = "1.15.1"
 
 # File-IPC contract version. Statusline writes this field on every snapshot
 # and history entry; bumped when the JSON shape changes incompatibly. Monitor's

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -87,6 +87,8 @@ from monitor import (
     render_picker,
     cached_cross_session_costs,
     _cost_cache,
+    cached_freshest_rate_limits,
+    _rl_fresh_cache,
     flush,
     SYNC_ON,
     SYNC_OFF,
@@ -670,6 +672,75 @@ class TestCachedCrossSessionCosts(unittest.TestCase):
         monitor._cost_scan_worker()
         self.assertEqual((_cost_cache["today"], _cost_cache["week"]), (0.0, 0.0))
         self.assertGreater(_cost_cache["t"], 0)
+
+
+# ---------------------------------------------------------------------------
+# cached_freshest_rate_limits
+# ---------------------------------------------------------------------------
+class TestCachedFreshestRateLimits(unittest.TestCase):
+
+    def setUp(self):
+        import tempfile, pathlib, monitor
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig = monitor.DATA_DIR
+        self._orig_cache = _rl_fresh_cache.copy()
+        monitor.DATA_DIR = pathlib.Path(self.tmpdir)
+        _rl_fresh_cache.update({"t": -1.0, "rl": None})  # force a fresh scan
+
+    def tearDown(self):
+        import shutil, monitor
+        monitor.DATA_DIR = self._orig
+        _rl_fresh_cache.update(self._orig_cache)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, sid, rl, age=0.0):
+        import pathlib, json, os, time
+        p = pathlib.Path(self.tmpdir) / f"{sid}.json"
+        payload = {"model": {"display_name": "X"}, "_schema_version": 1}
+        if rl is not None:
+            payload["rate_limits"] = rl
+        p.write_text(json.dumps(payload), encoding="utf-8")
+        if age:
+            t = time.time() - age
+            os.utime(p, (t, t))
+        return p
+
+    def test_empty_dir_returns_fallback(self):
+        fb = {"five_hour": {"used_percentage": 7}}
+        self.assertIs(cached_freshest_rate_limits(fb), fb)
+
+    def test_picks_freshest_across_sessions(self):
+        # Older snapshot 66%, newer snapshot 53% — newest mtime must win even
+        # though we ask while "viewing" the older one.
+        sid_old = "11111111-1111-1111-1111-111111111111"
+        sid_new = "22222222-2222-2222-2222-222222222222"
+        self._write(sid_old, {"five_hour": {"used_percentage": 66}}, age=3600)
+        self._write(sid_new, {"five_hour": {"used_percentage": 53}}, age=0)
+        fb = {"five_hour": {"used_percentage": 66}}  # the stale viewed session
+        out = cached_freshest_rate_limits(fb)
+        self.assertEqual(out["five_hour"]["used_percentage"], 53)
+
+    def test_fallback_when_no_snapshot_has_limits(self):
+        # A fresher snapshot without rate_limits must not shadow the fallback.
+        self._write("33333333-3333-3333-3333-333333333333", None, age=0)
+        fb = {"five_hour": {"used_percentage": 12}}
+        self.assertIs(cached_freshest_rate_limits(fb), fb)
+
+    def test_ttl_returns_cached(self):
+        import time
+        cached = {"five_hour": {"used_percentage": 99}}
+        _rl_fresh_cache.update({"t": time.monotonic(), "rl": cached})
+        # Even with a snapshot on disk, a warm TTL returns the cached value.
+        self._write("44444444-4444-4444-4444-444444444444",
+                    {"five_hour": {"used_percentage": 5}}, age=0)
+        self.assertIs(cached_freshest_rate_limits({"x": 1}, ttl=60), cached)
+
+    def test_render_frame_override_beats_session_field(self):
+        data = _full_data()
+        data["rate_limits"] = {"five_hour": {"used_percentage": 11, "resets_at": 9999999999}}
+        ov = {"five_hour": {"used_percentage": 88, "resets_at": 9999999999}}
+        line = next(l for l in render_frame(data, [], 80, 40, rate_limits=ov) if "5HL" in l)
+        self.assertIn("88", _ANSI_RE.sub("", line))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problém
Pri viacerých bežiacich session „zlietali" čísla rate limitov (5HL/7DL). 5H/7D sú **per-account** (zdieľané naprieč session), ale každá session ich zapisuje len do vlastného snapshotu a **idle snapshot zamrzne** (statusline beží len pri evente danej session). Monitor čítal `rate_limits` len z práve sledovanej session → zastarané/pred-reset hodnoty, keď bola iná session novšie aktívna.

Reprodukované na živých snapshotoch: idle session držala 5H=66 % (staré okno), kým aktívna ukazovala ~53 % (nové okno, reset +5 h). Zhodný `resets_at` + monotónne rastúce % naprieč session potvrdili jediný zdieľaný účtový čítač.

## Fix
- **`cached_freshest_rate_limits()`** — account-wide čítanie zo snapshotu s najnovším `mtime` naprieč všetkými session. Main-thread, 2 s TTL, rovnaký schema gate + `RESERVED_SIDS`/`_SID_RE` filter + `safe_read` cap ako `load_state`.
- **`render_frame(..., rate_limits=<override>)`** — event loop injektuje najčerstvejšiu hodnotu; bez override = pôvodné správanie (priami/test calleri nedotknutí).

Render ostal čistý — I/O scan je v event-loope, nie v `render_frame`.

## Obmedzenie
Snapshot **nenesie identifikátor účtu** → pri viacerých účtoch naraz môže ukázať limity cudzieho účtu. Single-account (bežný prípad) je presný. Evidované ako otvorená úloha pre doplnenie account-id do IPC schémy.

## Release v1.15.1 (PATCH)
Oprava čítania zo zlého zdroja (analógia v1.10.6 „reading from wrong file"). Súčasťou PR:
- `shared.VERSION` → `1.15.1`, `CHANGELOG.md` entry.
- IPC schéma nezmenená → `SCHEMA_VERSION` ostáva 1.
- Doc version markery (`ARCHITECTURE.md`, `FILE-IPC-CONTRACT.md` header+footer) + test baseline (`CONTRIBUTING.md`, `RELEASE.md`) zladené na 715.

## Overenie
- `py_compile` všetkých 5 modulov — OK.
- **715/715 testov** (`python3 src/tests.py`, +5 nových pre helper/override) — OK.
- `VERSION_RE` parsuje `1.15.1` (self-update kompatibilita) — OK.
- Funkčné overenie helpera proti živým dátam aj prázdnemu dir — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)