### PR TITLE
ci+docs: Version Gate na vynútenie bumpu + zjednotenie RELEASE.md

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -1,0 +1,69 @@
+name: Version Gate
+
+# Enforces the combined-PR release model (docs/RELEASE.md Section 5): a PR that
+# touches any runtime module (shared.PY_FILES) must bump shared.VERSION AND carry
+# a matching CHANGELOG entry, so a release-relevant change can never merge without
+# a version bump. Opt out of the gate for non-release runtime edits (pure refactor,
+# comment-only, internal cleanup) by applying the 'no-release' label to the PR.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  version-gate:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-release') }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0  # need base ref to diff against and read base shared.py
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Require version bump + CHANGELOG when runtime modules change
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE_REF"
+          BASE="origin/$BASE_REF"
+
+          # Runtime modules: single source of truth in shared.PY_FILES.
+          PY_FILES="$(python -c 'import shared; print(" ".join(shared.PY_FILES))')"
+
+          CHANGED="$(git diff --name-only "$BASE"...HEAD)"
+          echo "Changed files:"; echo "$CHANGED"
+
+          runtime_changed=0
+          for f in $PY_FILES; do
+            if echo "$CHANGED" | grep -qx "$f"; then
+              runtime_changed=1
+              echo "Runtime module changed: $f"
+            fi
+          done
+
+          if [ "$runtime_changed" -eq 0 ]; then
+            echo "No runtime module (PY_FILES) changed — version bump not required."
+            exit 0
+          fi
+
+          # Version parsing reuses shared.VERSION_RE — same regex update.py reads with.
+          head_ver="$(python -c 'import shared; print(shared.VERSION)')"
+          base_ver="$(git show "$BASE:shared.py" | python -c 'import sys, shared; m = shared.VERSION_RE.search(sys.stdin.read()); print(m.group(1) if m else "")')"
+          echo "shared.VERSION: base=$base_ver head=$head_ver"
+
+          if [ "$head_ver" = "$base_ver" ]; then
+            echo "::error::Runtime modules changed but shared.VERSION is still $head_ver. Bump shared.VERSION + add a CHANGELOG entry, or apply the 'no-release' label for a non-release edit."
+            exit 1
+          fi
+
+          ver_re="${head_ver//./\\.}"
+          if ! grep -Eq "^## v${ver_re}([^0-9]|$)" CHANGELOG.md; then
+            echo "::error::shared.VERSION is $head_ver but CHANGELOG.md has no '## v$head_ver' entry."
+            exit 1
+          fi
+
+          echo "Version gate passed: $base_ver -> $head_ver with a matching CHANGELOG entry."

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -225,8 +225,21 @@ Order matters. The self-update mechanism is commit-driven, not tag-driven
 PR — direct `git push origin main` is rejected even for the maintainer. The tag
 is still applied to the merge commit *after* it is on `main`:
 
+**Release model — combined PR.** The version bump rides in the *same* PR as the
+change it releases (the bump + CHANGELOG entry are part of the feature/fix PR,
+not a separate `release/vX.Y.Z` PR). The `Version Gate` check
+(`.github/workflows/version-gate.yml`) enforces this: any PR that touches a
+runtime module in `shared.PY_FILES` must bump `shared.VERSION` and add a matching
+`## vX.Y.Z` CHANGELOG entry, or the check fails. For a non-release runtime edit
+(pure refactor, comment-only, internal cleanup) apply the **`no-release`** label
+to skip the gate. A standalone version-only release (no accompanying code change)
+is still fine — it just trivially satisfies the gate. The example below shows the
+standalone shape; for a combined PR, stage your code changes alongside
+`CHANGELOG.md` + `shared.py` in step 1.
+
 ```bash
-# 1. Create a release branch and commit (CHANGELOG + shared.py version bump only)
+# 1. Branch and commit. Combined PR: add your code changes too. Standalone
+#    release: CHANGELOG + shared.py version bump only (as shown).
 git switch -c release/vX.Y.Z
 git add CHANGELOG.md shared.py
 git commit -m "chore(release): bump to vX.Y.Z"
@@ -235,15 +248,20 @@ git commit -m "chore(release): bump to vX.Y.Z"
 git push origin release/vX.Y.Z
 gh pr create --fill --base main
 
-# 3. Once CI is green (incl. release-smoke), squash-merge — this lands the
-#    version bump on main HEAD, which is what self-update reads
+# 3. Once the PR checks are green, squash-merge — this lands the version bump
+#    on main HEAD, which is what self-update reads. NOTE: release-smoke is NOT a
+#    PR check; it triggers on push to main, so it can only run AFTER this merge.
 gh pr merge --squash --delete-branch
 
-# 4. Sync local main to the merge commit, THEN tag it (after it is on main)
+# 4. Wait for release-smoke to pass on main BEFORE tagging — it runs the real
+#    update.py --apply path from the previous tag (the pre-tag self-update gate).
+gh run watch "$(gh run list --workflow=release-smoke.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId')"
+
+# 5. Sync local main to the merge commit, THEN tag it (after it is on main)
 git switch main && git pull --ff-only origin main
 git tag vX.Y.Z
 
-# 5. Push the tag separately
+# 6. Push the tag separately
 git push origin vX.Y.Z
 ```
 
@@ -298,9 +316,11 @@ There is no `next`/`beta` channel or canary cohort — a single maintainer does
 not have the operational capacity to soak releases, and adding channels would
 complicate the update path for a marginal cohort. The accepted mitigations are:
 
-- **Pre-merge gate:** `release-smoke.yml` runs the *real* `update.py --apply`
-  path from the previous tag on every push to `main`, so a broken self-update
-  is caught in CI before users pull it.
+- **Pre-tag gate (post-merge):** `release-smoke.yml` runs the *real*
+  `update.py --apply` path from the previous tag on every push to `main`. It
+  triggers *after* the merge (not on the PR), so the merge precedes the smoke
+  run; wait for it to pass before tagging (Section 5, step 4). A broken
+  self-update is caught here before the release is tagged and announced.
 - **Per-user rollback:** `update.py --apply` writes a `pre-update-*` tag before
   pulling (see Section 7), so any user can revert in one command.
 - **Fast-forward-only safety:** `git pull --ff-only` refuses to apply a


### PR DESCRIPTION
Pokračovanie po v1.15.1 (commit sa nestihol do #72 pred jeho merge).

## Version Gate (`.github/workflows/version-gate.yml`)
PR meniaci runtime modul (`shared.PY_FILES`) musí bumpnúť `shared.VERSION` **a** mať `## vX.Y.Z` CHANGELOG entry, inak check faily. Výnimka pre non-release runtime edit (refactor/comment/internal) cez label **`no-release`**.
- Verzia sa parsuje cez `shared.VERSION_RE` (rovnaký regex ako `update.py`), runtime moduly cez `shared.PY_FILES` — single source of truth.
- Logika overená lokálne: `1.15.0 → 1.15.1` + CHANGELOG → pass; rovnaká verzia → fail.

## RELEASE.md zjednotenie
- §5 prepísané na **spojený model** (bump v tom istom PR ako zmena; štandard zvolený ownerom).
- §5/§6: `release-smoke` je **pre-tag (post-merge)** gate, nie „pre-merge" — opravená faktická chyba („green incl. release-smoke" pred merge je nemožné, beží až na push to main). Doplnený explicitný `gh run watch` krok pred tagom.

Tento PR má label `no-release` (nemení PY_FILES, žiadny bump netreba).

🤖 Generated with [Claude Code](https://claude.com/claude-code)