### PR TITLE
fix: harden JSON readers and list mode cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.15.2 — 2026-06-19
+
+**Bug fixes and hardening:**
+- Treat pathological JSON recursion failures like malformed input across the
+  statusline and monitor readers. Snapshot, history, transcript-title, rate
+  limit, stats-cache and subagent scans now skip or degrade safely instead of
+  letting `RecursionError` escape from `json.loads()`.
+- Restore the Windows console output code page after `monitor.py --list`.
+  The one-shot list mode still enables UTF-8 for session names and AI titles,
+  but no longer leaves the parent console in the changed code page.
+- Sanitize fallback tool abbreviations before rendering agent-modal labels, so
+  unknown tool names cannot carry terminal control bytes into compact labels.
+
+**Tests:** 723 passing (+8).
+
 ## v1.15.1 — 2026-06-14
 
 **Bug fixes:**

--- a/monitor.py
+++ b/monitor.py
@@ -173,7 +173,7 @@ def _aggregate_transcript(jl, st, sid, is_subagent, cutoff,
             for line in f:
                 try:
                     obj = json.loads(line)
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, RecursionError):
                     continue
 
                 ts_str = obj.get("timestamp", "")
@@ -938,7 +938,7 @@ def calc_cross_session_costs():
         for ln in raw.splitlines():
             try:
                 entries.append(json.loads(ln))
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, RecursionError):
                 pass
         if not entries:
             continue
@@ -1079,7 +1079,7 @@ def list_sessions():
                 "ai_title": _scan_ai_title(d.get("transcript_path")) or "",
                 "cwd": _sanitize(d.get("cwd", "")),
             })
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError, RecursionError):
             pass
     sessions.sort(key=lambda s: s["mtime"], reverse=True)
     return sessions
@@ -1098,7 +1098,7 @@ def load_state(sid):
         return None
     try:
         d = json.loads(raw.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError):
         return None
     # IPC schema gate (M-cross-2): statusline tags every snapshot with
     # _schema_version. A snapshot written by a NEWER build than this one —
@@ -1149,7 +1149,7 @@ def cached_freshest_rate_limits(fallback, ttl=2.0):
                 if raw is None:
                     continue
                 d = json.loads(raw.decode("utf-8"))
-            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError, RecursionError):
                 continue
             if not isinstance(d, dict):
                 continue
@@ -1824,7 +1824,7 @@ def _scan_ai_title(transcript_path):
                 continue
             try:
                 obj = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
+            except (json.JSONDecodeError, ValueError, RecursionError):
                 continue
             if isinstance(obj, dict) and obj.get("type") == "ai-title":
                 t = obj.get("aiTitle")
@@ -1899,7 +1899,7 @@ def _aggregate_session_cost(data):
                     continue
                 try:
                     rec = json.loads(line)
-                except (json.JSONDecodeError, ValueError):
+                except (json.JSONDecodeError, ValueError, RecursionError):
                     continue
                 if rec.get("type") != "assistant":
                     continue
@@ -2722,7 +2722,7 @@ def _read_stats_cache():
         return None, 0
     try:
         obj = json.loads(raw.decode("utf-8", errors="replace"))
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError, RecursionError):
         return None, 0
     if not isinstance(obj, dict):
         return None, 0
@@ -3058,7 +3058,7 @@ def scan_subagents(transcript_path, ttl=_SUBAGENTS_TTL):
             for line in raw.decode("utf-8", errors="replace").splitlines():
                 try:
                     o = json.loads(line)
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, RecursionError):
                     continue
                 if not isinstance(o, dict):
                     continue  # valid JSON but not an object (e.g. bare array)
@@ -3154,7 +3154,7 @@ def _tool_abbr(name):
     if name in _TOOL_ABBR:
         return _TOOL_ABBR[name]
     base = name.split("__")[-1] if name.startswith("mcp__") else name
-    return base[:4].upper() or "--"
+    return _sanitize(base[:4]).upper() or "--"
 
 
 def render_agents(data, cols, rows, active_only=False):
@@ -3357,18 +3357,21 @@ def main():
     ensure_utf8_stdout()
     # NEW-003: --list emits diacritics from session_name / ai_title and
     # needs Windows console CP 65001 even though it skips the full TUI
-    # _setup_term. Restore is handled by atexit cleanup only when set
-    # for the interactive path; for the one-shot --list we deliberately
-    # leave the console in UTF-8 mode since the process exits right
-    # after the listing — no chance for follow-up commands to be
-    # affected within this process.
+    # _setup_term. The one-shot path restores the console in its own
+    # finally block because it does not register the interactive atexit
+    # cleanup path.
     _set_console_utf8()
 
     if args.list:
-        for s in list_sessions():
-            tag = "(stale)" if s["stale"] else "(live)"
-            nm = s["session_name"] or s.get("ai_title") or "--"
-            print(f"  {s['id'][:16]}  {s['model']:>8}  {nm}  {s['cwd']}  {tag}")
+        try:
+            for s in list_sessions():
+                tag = "(stale)" if s["stale"] else "(live)"
+                nm = s["session_name"] or s.get("ai_title") or "--"
+                print(f"  {s['id'][:16]}  {s['model']:>8}  {nm}  {s['cwd']}  {tag}")
+        finally:
+            # Undo the console-wide CP65001 change so the parent shell is left
+            # as found (Windows); no-op if no CP was saved / on non-Windows.
+            _restore_term()
         return
 
     # Singleton lock — interactive monitor only. Two concurrent dashboards

--- a/shared.py
+++ b/shared.py
@@ -53,7 +53,7 @@ DATA_DIR = pathlib.Path(tempfile.gettempdir()) / DATA_DIR_NAME
 VERSION_RE = re.compile(r'^VERSION\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
 
 # Single source of truth for app version — imported by monitor.py, pulse.py, update.py
-VERSION = "1.15.1"
+VERSION = "1.15.2"
 
 # File-IPC contract version. Statusline writes this field on every snapshot
 # and history entry; bumped when the JSON shape changes incompatibly. Monitor's

--- a/statusline.py
+++ b/statusline.py
@@ -260,7 +260,7 @@ def main():
             return
         raw = raw_bytes.decode("utf-8", errors="replace")
         data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError, RecursionError):
         return
 
     sid = data.get("session_id") or "default"
@@ -367,7 +367,7 @@ def _trim_history(path: pathlib.Path):
         for ln in kept:
             try:
                 json.loads(ln)
-            except (json.JSONDecodeError, ValueError):
+            except (json.JSONDecodeError, ValueError, RecursionError):
                 continue
             valid.append(ln)
         trimmed = "\n".join(valid) + "\n" if valid else ""

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -726,6 +726,13 @@ class TestCachedFreshestRateLimits(unittest.TestCase):
         fb = {"five_hour": {"used_percentage": 12}}
         self.assertIs(cached_freshest_rate_limits(fb), fb)
 
+    def test_recursionerror_snapshot_returns_fallback(self):
+        self._write("33333333-3333-3333-3333-333333333333",
+                    {"five_hour": {"used_percentage": 99}}, age=0)
+        fb = {"five_hour": {"used_percentage": 12}}
+        with patch("monitor.json.loads", side_effect=RecursionError("json depth")):
+            self.assertIs(cached_freshest_rate_limits(fb), fb)
+
     def test_ttl_returns_cached(self):
         import time
         cached = {"five_hour": {"used_percentage": 99}}
@@ -2161,6 +2168,13 @@ class TestListSessions(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["id"], sid)
 
+    def test_recursionerror_snapshot_skipped(self):
+        sid = "deepSession"
+        p = pathlib.Path(self._tmp) / f"{sid}.json"
+        p.write_text(json.dumps({"model": {"display_name": "Opus"}, "session_name": "", "cwd": ""}), encoding="utf-8")
+        with patch("monitor.json.loads", side_effect=RecursionError("json depth")):
+            self.assertEqual(list_sessions(), [])
+
     def test_rls_json_skipped(self):
         p = pathlib.Path(self._tmp) / "rls.json"
         p.write_text(json.dumps({"status": "ok"}), encoding="utf-8")
@@ -2253,6 +2267,13 @@ class TestLoadState(unittest.TestCase):
         result = load_state(sid)
         self.assertIsInstance(result, dict)
         self.assertEqual(result["session_id"], sid)
+
+    def test_recursionerror_returns_none(self):
+        sid = "deepSess"
+        p = pathlib.Path(self._tmp) / f"{sid}.json"
+        p.write_text(json.dumps({"session_id": sid}), encoding="utf-8")
+        with patch("monitor.json.loads", side_effect=RecursionError("json depth")):
+            self.assertIsNone(load_state(sid))
 
     def test_invalid_sid_returns_none(self):
         result = load_state("../evil")
@@ -3567,6 +3588,27 @@ class TestScanAiTitle(unittest.TestCase):
             result = self._monitor._scan_ai_title(str(jl))
         self.assertEqual(result, "Survived")
 
+    def test_recursionerror_line_skipped(self):
+        jl = self._proj / "session5b.jsonl"
+        jl.write_text(
+            json.dumps({"type": "user", "content": "deep"}) + "\n"
+            + json.dumps({"type": "ai-title", "aiTitle": "Survived depth"}) + "\n",
+            encoding="utf-8",
+        )
+        orig_loads = json.loads
+        calls = {"n": 0}
+
+        def flaky_loads(raw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RecursionError("json depth")
+            return orig_loads(raw)
+
+        with patch.object(self._monitor, "CLAUDE_PROJECTS_DIR", self._fake_root), \
+             patch("monitor.json.loads", side_effect=flaky_loads):
+            result = self._monitor._scan_ai_title(str(jl))
+        self.assertEqual(result, "Survived depth")
+
     def test_oversize_file_returns_none(self):
         jl = self._proj / "session6.jsonl"
         # Title at the head still must be ignored when the transcript exceeds the cap.
@@ -4120,6 +4162,18 @@ class TestMainSingleton(unittest.TestCase):
             _m.main()
         mock_lock.assert_not_called()
 
+    def test_main_list_mode_restores_terminal(self):
+        """--list sets UTF-8 output mode, then restores it before returning."""
+        with patch("sys.argv", ["monitor.py", "--list"]), \
+             patch("monitor.ensure_utf8_stdout"), \
+             patch("monitor._set_console_utf8") as mock_set, \
+             patch("monitor._restore_term") as mock_restore, \
+             patch("monitor.list_sessions", return_value=[]):
+            import monitor as _m
+            _m.main()
+        mock_set.assert_called_once()
+        mock_restore.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # scan_subagents / render_agents — Agents fan-out modal
@@ -4581,6 +4635,10 @@ class TestAuditFixesV1130(unittest.TestCase):
         # Every label stays short enough to keep the agent line compact.
         for v in monitor._TOOL_ABBR.values():
             self.assertLessEqual(len(v), 4)
+
+    def test_tool_abbr_strips_control_chars(self):
+        self.assertEqual(monitor._tool_abbr("Bad\x1bTool"), "BAD")
+        self.assertNotIn("\x1b", monitor._tool_abbr("mcp__x__\x1b[31mtool"))
 
     # ---- #6: _picker_order is the single source of truth ----
     def test_picker_order_active_first_and_capped(self):

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -421,6 +421,32 @@ class TestTrimHistory(unittest.TestCase):
             json.loads(ln)  # every surviving line is valid JSON
         p.unlink()
 
+    def test_trim_drops_recursionerror_lines(self):
+        import json, tempfile, pathlib
+        from statusline import _trim_history, HISTORY_TRIM_TO
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl",
+                                          delete=False, encoding="utf-8")
+        lines = [f'{{"i": {i}}}' for i in range(HISTORY_TRIM_TO + 10)]
+        lines[-5] = '{"deep": true}'
+        tmp.write("\n".join(lines) + "\n")
+        tmp.close()
+        p = pathlib.Path(tmp.name)
+        orig_loads = json.loads
+
+        def flaky_loads(raw):
+            if raw == '{"deep": true}':
+                raise RecursionError("json depth")
+            return orig_loads(raw)
+
+        try:
+            with patch("statusline.json.loads", side_effect=flaky_loads):
+                _trim_history(p)
+            result = p.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(result), HISTORY_TRIM_TO - 1)
+            self.assertNotIn('{"deep": true}', result)
+        finally:
+            p.unlink()
+
 
 # ---------------------------------------------------------------------------
 # _load_history_for_rates
@@ -650,6 +676,19 @@ class TestStatuslineMainE2E(unittest.TestCase):
              patch.object(_sl.sys, "stdout", fake_stdout), \
              patch.object(_sl, "ensure_utf8_stdout", lambda: None):
             _sl.main()  # must not raise
+
+    def test_main_recursionerror_returns_silently(self):
+        import io, json as _json
+        import statusline as _sl
+        fake_stdin = self._fake_stdin(_json.dumps({"session_id": "deepjson"}).encode("utf-8"))
+        fake_stdout = io.StringIO()
+        with patch.object(_sl.sys, "stdin", fake_stdin), \
+             patch.object(_sl.sys, "stdout", fake_stdout), \
+             patch.object(_sl, "ensure_utf8_stdout", lambda: None), \
+             patch.object(_sl.json, "loads", side_effect=RecursionError("json depth")):
+            _sl.main()  # must not raise
+        self.assertEqual(fake_stdout.getvalue(), "")
+        self.assertFalse(any(self._base.glob("*.json")) if self._base.exists() else False)
 
     def test_main_utf8_session_name_preserved_through_pipeline(self):
         """NEW-002 regression: Slovak diacritics in session_name must


### PR DESCRIPTION
## Summary
- Handle JSON `RecursionError` as malformed input in monitor/statusline reader paths.
- Restore the Windows console output code page after `monitor.py --list`.
- Sanitize fallback tool abbreviations and bump the release notes/version to v1.15.2.

## Verification
- `python3 tests.py`
- `python3 -c "import py_compile, shared; [py_compile.compile(f, doraise=True) for f in shared.PY_FILES]"`
- `python3 -m py_compile monitor.py statusline.py tests/test_monitor.py tests/test_statusline.py`
- `git diff --check`
- Bandit: no issues identified