### PR TITLE
[codex] fix Windows symlink test skip

### DIFF
--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -692,7 +692,10 @@ class TestPulseLog(unittest.TestCase):
         target = pulse.LOG_PATH.parent / "_symlink_target.log"
         target.write_text('{"ts": 9999999999, "score": 90}\n', encoding="utf-8")
         try:
-            pulse.LOG_PATH.symlink_to(target)
+            try:
+                pulse.LOG_PATH.symlink_to(target)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks not supported")
             pulse.cleanup_log_startup()
             # LOG_PATH is still a symlink — cleanup must not have rewritten it
             self.assertTrue(pulse.LOG_PATH.is_symlink(),


### PR DESCRIPTION
## What changed

- Wrap the `pulse.LOG_PATH.symlink_to(...)` fixture setup in `tests/test_pulse.py` with the same `OSError` / `NotImplementedError` skip guard used by existing symlink tests.

## Why

On Windows accounts without symlink creation privileges, the test failed before it could verify the cleanup behavior. Platforms with symlink support still execute the security assertion; unsupported environments now report a skip instead of an error.

## Validation

- `py -m unittest tests.test_pulse.TestPulseLog.test_cleanup_rejects_symlink`
- `py tests.py` (`731` tests, `14` skipped)
- Runtime compile smoke for `shared.PY_FILES`